### PR TITLE
added check for empty display fields while rendering

### DIFF
--- a/fields/acf-Typography-v4.php
+++ b/fields/acf-Typography-v4.php
@@ -463,7 +463,7 @@ class acf_field_Typography extends acf_field {
 		
 		// create Field HTML
 		
-		if( sizeof($field['display_properties']) > 0){
+		if( !empty( $field['display_properties'] ) && sizeof($field['display_properties']) > 0){
 
 			foreach( $field['display_properties'] as $f ){
 				

--- a/fields/acf-Typography-v5.php
+++ b/fields/acf-Typography-v5.php
@@ -380,7 +380,7 @@ class acf_field_Typography extends acf_field {
 		
 		// create Field HTML
 		
-		if( sizeof($field['display_properties']) > 0){
+		if( !empty( $field['display_properties'] ) && sizeof($field['display_properties']) > 0){
 		    
 		    foreach( $field['display_properties'] as $f ){
 		        


### PR DESCRIPTION
Error occurs in plugin/fields/acf-Typography-v5.php/line:383.
There should be a check to see if $field['display_properties'] is not empty.
Like this if( ! empty( $field['display_properties'] ) && sizeof($field['display_properties']) > 0){}
If a user selects no field to display in the typography metabox then it should not break.