### PR TITLE
Fix issue url too long

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -101,12 +101,15 @@ function acft_enqueue_google_fonts_file() {
     $all_fields = array_merge_recursive( $all_post_fields, $all_option_fields );
 
     if( is_array($all_fields) ){
-        
+
         array_walk_recursive($all_fields, function($item, $key) use (&$font_family, &$font_weight) {
             if( $key === 'font_family' )
                 $font_family[] = $item;
-            elseif( $key === 'font_weight' )
-                $font_weight[] = $item;
+            elseif( $key === 'font_weight' ) {
+				if (!in_array($item, $font_weight)) {
+					$font_weight[] = $item;
+				}
+			}
         });
 
     }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -104,7 +104,9 @@ function acft_enqueue_google_fonts_file() {
 
         array_walk_recursive($all_fields, function($item, $key) use (&$font_family, &$font_weight) {
             if( $key === 'font_family' )
-                $font_family[] = $item;
+			    if (!in_array($item, $font_family)) {
+				$font_family[] = $item;
+			}
             elseif( $key === 'font_weight' ) {
 				if (!in_array($item, $font_weight)) {
 					$font_weight[] = $item;


### PR DESCRIPTION
This fixes the issue when adding multiple fonts, `array_walk_recursive` adds same font_weight multiple times which increases the url length and breaks the font loading logic. I've added the check to prevent adding same font _weight multiple times.