### PR TITLE
Proposed v3.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+##### 3.2.4
+* [NEW] Plugin now officially supports ACF v6!
+* [NEW] Tested up to PHP 8.2.
+* [BUG] Fixed 'Notice: Trying to get property ID of non-object' when enqueueing font files on non-objects. ( WP Support )
+* [BUG] Fixed 'Warning: failed to open stream: HTTP request failed' when bad API Key supplied, or other API connection issues. #27
+* [NEW] Admin Settings - checks and help messages for Google API Key/connection issues.
+* [NEW] Admin Settings - description and link provided for getting Google Fonts API key.
+* [NEW] Admin Settings - checks to make sure ACF is installed and activated.
+* [UPDATE] Translation string and textdomain updates to get plugin translation-ready (coming next release).
+* [UPDATE] Added a few minor additional checks for some variables to prevent possible errors in the future.
+* [UPDATE] Minor code cleanup for readability. 
+
 ##### 3.2.3
 * Added new font-weight values
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 A Typography Add-on for the Advanced Custom Fields Plugin.
 
   - Requires at least: WP 3.5.0
-  - Tested up to: WP 6.0
+  - Tested up to: WP 6.0.3
   - Tested up to: PHP 8.2
-  - Tested up to: ACF 6.0.3
+  - Tested up to: ACF 6.0
   - Stable: 3.2.4
   - Latest: 3.2.4
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Typography Add-on for the Advanced Custom Fields Plugin.
   - Requires at least: WP 3.5.0
   - Tested up to: WP 6.0
   - Tested up to: PHP 8.2
-  - Tested up to: ACF v6
+  - Tested up to: ACF 6.0
   - Stable: 3.2.4
   - Latest: 3.2.4
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Typography Add-on for the Advanced Custom Fields Plugin.
   - Requires at least: WP 3.5.0
   - Tested up to: WP 6.0
   - Tested up to: PHP 8.2
-  - Tested up to: ACF 6.0
+  - Tested up to: ACF 6.0.3
   - Stable: 3.2.4
   - Latest: 3.2.4
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,14 @@ A Typography Add-on for the Advanced Custom Fields Plugin.
 
   - Requires at least: WP 3.5.0
   - Tested up to: WP 6.0
-  - Stable: 3.2.3
-  - Latest: 3.2.3
+  - Stable: 3.2.4
+  - Latest: 3.2.4
 
 ## Description
 Typography field type for "Advanced Custom Fields" plugin that lets you add different text properties e.g. Font Size, Font Family, Font Color etc.
+
+If you want any kind of font/typography features within ACF, this is the plugin for you! There's nothing else like it!
+
 ### Supported Subfields
 * Font Size
 * Font Family
@@ -55,6 +58,7 @@ the_typography_sub_field( $selector, $property, [$format_value] );
 ## Compatibility
 
 This ACF field type is compatible with:
+* ACF plugin v4, v5 & v6
 * Free and paid versions of the ACF plugin
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A Typography Add-on for the Advanced Custom Fields Plugin.
 
   - Requires at least: WP 3.5.0
   - Tested up to: WP 6.0
+  - Tested up to: PHP 8.2
+  - Tested up to: ACF v6
   - Stable: 3.2.4
   - Latest: 3.2.4
 

--- a/acf-typography.php
+++ b/acf-typography.php
@@ -24,6 +24,8 @@ if( $acft_options && $acft_options['google_key'] )
 if( !class_exists('acf_plugin_Typography') ) :
 
 	class acf_plugin_Typography {
+
+			var array $settings; // php8.2 compatibility (deprecated dynamic properties)
 		
 			/*
 			*  __construct

--- a/acf-typography.php
+++ b/acf-typography.php
@@ -25,7 +25,7 @@ if( !class_exists('acf_plugin_Typography') ) :
 
 	class acf_plugin_Typography {
 
-			var array $settings; // php8.2 compatibility (deprecated dynamic properties)
+			var $settings; // php8.2 compatibility (deprecated dynamic properties)
 		
 			/*
 			*  __construct

--- a/acf-typography.php
+++ b/acf-typography.php
@@ -4,11 +4,12 @@
 Plugin Name: Advanced Custom Fields: Typography Field
 Plugin URI: https://wordpress.org/plugins/acf-typography-field
 Description: A Typography Add-on for the Advanced Custom Fields Plugin.
-Version: 3.2.3
+Version: 3.2.4
 Author: Mujahid Ishtiaq
 Author URI: https://github.com/mujahidi
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: acf-typography
 */
 
 // exit if accessed directly
@@ -17,7 +18,7 @@ if( ! defined( 'ABSPATH' ) ) exit;
 $acft_options = get_option( 'acft_settings' );
 
 if( $acft_options && $acft_options['google_key'] )
-	define('YOUR_API_KEY', $acft_options['google_key']);
+	define( 'YOUR_API_KEY', $acft_options['google_key'] );
 
 // check if class already exists
 if( !class_exists('acf_plugin_Typography') ) :
@@ -41,7 +42,7 @@ if( !class_exists('acf_plugin_Typography') ) :
 			
 			// vars
 			$this->settings = array(
-				'version'	=> '3.2.2',
+				'version'	=> '3.2.4',
 				'url'		=> plugin_dir_url( __FILE__ ),
 				'path'		=> plugin_dir_path( __FILE__ )
 			);
@@ -51,12 +52,12 @@ if( !class_exists('acf_plugin_Typography') ) :
 			require plugin_dir_path( __FILE__ ) . 'includes/admin_settings.php';
 			require plugin_dir_path( __FILE__ ) . 'includes/functions.php';
 
-			// include field
-			add_action('acf/include_field_types', 	array($this, 'include_field_types')); // v5
-			add_action('acf/register_fields', 		array($this, 'include_field_types')); // v4
-			add_action('acf/field_group/admin_enqueue_scripts', array($this, 'field_group_admin_enqueue_scripts'));
-			
-		}
+                        // include field
+                        add_action('acf/include_field_types', array($this, 'include_field_types')); // v5, v6
+                        add_action('acf/register_fields', array($this, 'include_field_types')); // v4
+                        add_action('acf/field_group/admin_enqueue_scripts', array($this, 'field_group_admin_enqueue_scripts'));
+ 
+                }
 		
 		
 		/*
@@ -73,10 +74,17 @@ if( !class_exists('acf_plugin_Typography') ) :
 		*/
 		
 		function include_field_types( $version = false ) {
-			
-			// support empty $version
-			if( !$version ) $version = 4;
-			
+                    
+                    	/* 
+                         * ACF currently does not check for, or use version 6.
+                         * It only checks for/uses v5 even when v6 installed/active.
+                         * Eventually they'll push for v6-specific fields.
+                         * Until then, we go ahead & specify the version ourselves.
+                         */
+                        if ( get_option( 'acf_version' ) ) $version = explode( '.', get_option( 'acf_version' ) )[0];
+                    
+			// if version is any version other than 5 or 6, set version to 4
+			if ( !$version || !$version === 5 || !$version === 6 ) $version = 4;
 			
 			// include
 			include_once('fields/acf-Typography-v' . $version . '.php');
@@ -91,10 +99,8 @@ if( !class_exists('acf_plugin_Typography') ) :
 		
 	}
 
-
 	// initialize
 	new acf_plugin_Typography();
-
 
 // class_exists check
 endif;

--- a/acf-typography.php
+++ b/acf-typography.php
@@ -25,77 +25,77 @@ if( !class_exists('acf_plugin_Typography') ) :
 
 	class acf_plugin_Typography {
 		
-		/*
-		*  __construct
-		*
-		*  This function will setup the class functionality
-		*
-		*  @type	function
-		*  @date	17/02/2016
-		*  @since	1.0.0
-		*
-		*  @param	n/a
-		*  @return	n/a
-		*/
-		
-		function __construct() {
+			/*
+			*  __construct
+			*
+			*  This function will setup the class functionality
+			*
+			*  @type	function
+			*  @date	17/02/2016
+			*  @since	1.0.0
+			*
+			*  @param	n/a
+			*  @return	n/a
+			*/
 			
-			// vars
-			$this->settings = array(
-				'version'	=> '3.2.4',
-				'url'		=> plugin_dir_url( __FILE__ ),
-				'path'		=> plugin_dir_path( __FILE__ )
-			);
+			function __construct() {
+				
+					// vars
+					$this->settings = array(
+						'version'	=> '3.2.4',
+						'url'		=> plugin_dir_url( __FILE__ ),
+						'path'		=> plugin_dir_path( __FILE__ )
+					);
+
+					// include files
+					require plugin_dir_path( __FILE__ ) . 'includes/api-template.php';
+					require plugin_dir_path( __FILE__ ) . 'includes/admin_settings.php';
+					require plugin_dir_path( __FILE__ ) . 'includes/functions.php';
+
+					// include field
+					add_action('acf/include_field_types', array($this, 'include_field_types')); // v5, v6
+					add_action('acf/register_fields', array($this, 'include_field_types')); // v4
+					add_action('acf/field_group/admin_enqueue_scripts', array($this, 'field_group_admin_enqueue_scripts'));
+	
+			}
 			
-			// include files
-			require plugin_dir_path( __FILE__ ) . 'includes/api-template.php';
-			require plugin_dir_path( __FILE__ ) . 'includes/admin_settings.php';
-			require plugin_dir_path( __FILE__ ) . 'includes/functions.php';
-
-                        // include field
-                        add_action('acf/include_field_types', array($this, 'include_field_types')); // v5, v6
-                        add_action('acf/register_fields', array($this, 'include_field_types')); // v4
-                        add_action('acf/field_group/admin_enqueue_scripts', array($this, 'field_group_admin_enqueue_scripts'));
- 
-                }
-		
-		
-		/*
-		*  include_field_types
-		*
-		*  This function will include the field type class
-		*
-		*  @type	function
-		*  @date	17/02/2016
-		*  @since	1.0.0
-		*
-		*  @param	$version (int) major ACF version. Defaults to false
-		*  @return	n/a
-		*/
-		
-		function include_field_types( $version = false ) {
-                    
-                    	/* 
-                         * ACF currently does not check for, or use version 6.
-                         * It only checks for/uses v5 even when v6 installed/active.
-                         * Eventually they'll push for v6-specific fields.
-                         * Until then, we go ahead & specify the version ourselves.
-                         */
-                        if ( get_option( 'acf_version' ) ) $version = explode( '.', get_option( 'acf_version' ) )[0];
-                    
-			// if version is any version other than 5 or 6, set version to 4
-			if ( !$version || !$version === 5 || !$version === 6 ) $version = 4;
 			
-			// include
-			include_once('fields/acf-Typography-v' . $version . '.php');
+			/*
+			*  include_field_types
+			*
+			*  This function will include the field type class
+			*
+			*  @type	function
+			*  @date	17/02/2016
+			*  @since	1.0.0
+			*
+			*  @param	$version (int) major ACF version. Defaults to false
+			*  @return	n/a
+			*/
 			
-		}
+			function include_field_types( $version = false ) {
+						
+					/**
+					 * ACF currently does not check for, or use version 6.
+					 * It only checks for/uses v5 even when v6 installed/active.
+					 * Eventually they'll push for v6-specific fields.
+					 * Until then, we go ahead & specify the version ourselves.
+					 */
+					if ( get_option( 'acf_version' ) ) $version = explode( '.', get_option( 'acf_version' ) )[0];
+							
+					// if version is any version other than 5 or 6, set version to 4
+					if ( !$version || !$version === 5 || !$version === 6 ) $version = 4;
+					
+					// include
+					include_once('fields/acf-Typography-v' . $version . '.php');
+				
+			}
 
-		function field_group_admin_enqueue_scripts(){
+			function field_group_admin_enqueue_scripts(){
 
-			wp_enqueue_script( 'acf-typography-fieldgroup-script', plugin_dir_url( __FILE__ ) . 'assets/js/admin-field-group.js', array(), $this->settings['version'] );
+					wp_enqueue_script( 'acf-typography-fieldgroup-script', plugin_dir_url( __FILE__ ) . 'assets/js/admin-field-group.js', array(), $this->settings['version'] );
 
-		}
+			}
 		
 	}
 

--- a/fields/acf-Typography-v4.php
+++ b/fields/acf-Typography-v4.php
@@ -12,7 +12,7 @@ class acf_field_Typography extends acf_field {
 	
 	// vars
 	var $settings, // will hold info such as dir / path
-            $defaults; // will hold default field options
+		$defaults; // will hold default field options
 		
 		
 	/*
@@ -35,17 +35,17 @@ class acf_field_Typography extends acf_field {
 			// This makes life easy when creating the field options as you don't need to use any if( isset('') ) logic. eg:
 			'display_properties'	=> array(),
 			'required_properties'	=> array(),
-			'font_size'		=> 15,
-			'font_weight'		=> '400',
-			'font_family'		=> 'Arial, Helvetica, sans-serif',
-			'font_style'		=> 'normal',
-                        'font_variant'		=> 'normal',
-                        'font_stretch'		=> 'normal',
-			'text_align'		=> 'left',
-			'letter_spacing'	=> 0,
-			'text_decoration'	=> 'none',
-			'text_color'		=> '#000',
-			'text_transform'	=> 'none'
+			'font_size'				=> 15,
+			'font_weight'			=> '400',
+			'font_family'			=> 'Arial, Helvetica, sans-serif',
+			'font_style'			=> 'normal',
+			'font_variant'			=> 'normal',
+			'font_stretch'			=> 'normal',
+			'text_align'			=> 'left',
+			'letter_spacing'		=> 0,
+			'text_decoration'		=> 'none',
+			'text_color'			=> '#000',
+			'text_transform'		=> 'none'
 		);
 		
 		$this->font_family = array(
@@ -96,11 +96,11 @@ class acf_field_Typography extends acf_field {
 			'italic'	=> 'italic',
 			'oblique'	=> 'oblique',
 		);
-                $this->font_variant = array(
+        $this->font_variant = array(
 			'normal'     => 'normal',
-                        'small-caps' => 'small-caps',
-                        'initial'    => 'initial',
-                        'inherit'    => 'inherit'
+            'small-caps' => 'small-caps',
+            'initial'    => 'initial',
+            'inherit'    => 'inherit'
 		);
 		$this->font_stretch = array(
 			'ultra-condensed'   => 'ultra-condensed',
@@ -124,20 +124,20 @@ class acf_field_Typography extends acf_field {
 			'initial'	=> 'initial'
 		);
 		$this->text_decoration = array(
-			'none' 		=> 'none',
-			'underline' 	=> 'underline',
-			'overline' 	=> 'overline',
+			'none'			=> 'none',
+			'underline'		=> 'underline',
+			'overline'		=> 'overline',
 			'line-through' 	=> 'line-through',
-			'initial' 	=> 'initial',
-			'inherit' 	=> 'inherit'
+			'initial'		=> 'initial',
+			'inherit'		=> 'inherit'
 		);
 		$this->text_transform = array(
-			'none' 		=> 'none',
+			'none' 			=> 'none',
 			'capitalize' 	=> 'capitalize',
 			'uppercase' 	=> 'uppercase',
 			'lowercase' 	=> 'lowercase',
-			'initial' 	=> 'initial',
-			'inherit' 	=> 'inherit'
+			'initial'		=> 'initial',
+			'inherit'		=> 'inherit'
 		);
 		
 		
@@ -180,22 +180,22 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'      =>  'checkbox',
-					'name'      =>  'fields['.$key.'][display_properties]',
-					'value'     =>  $field['display_properties'],
-					'choices'   =>  array(
-						'font_size'         =>  __("Font Size",'acf-typography'),
-						'font_family'       =>  __("Font Family",'acf-typography'),
-						'font_weight'       =>  __("Font Weight",'acf-typography'),
-						'font_style'        =>  __("Font Style",'acf-typography'),
-                                                'font_variant'      =>  __("Font Variant",'acf-typography'),
-                                                'font_stretch'      =>  __("Font Stretch",'acf-typography'),
-						'line_height'       =>  __("Line Height",'acf-typography'),
-						'letter_spacing'    =>  __("Letter Spacing",'acf-typography'),
-						'text_align'        =>  __("Text Align",'acf-typography'),
-						'text_color'        =>  __("Text Color",'acf-typography'),
-						'text_decoration'   =>  __("Text Decoration",'acf-typography'),
-						'text_transform'    =>  __("Text Transform",'acf-typography'),
+					'type'		=>  'checkbox',
+					'name'		=>  'fields['.$key.'][display_properties]',
+					'value'		=>  $field['display_properties'],
+					'choices'	=>  array(
+						'font_size'			=>  __("Font Size",'acf-typography'),
+						'font_family'		=>  __("Font Family",'acf-typography'),
+						'font_weight'		=>  __("Font Weight",'acf-typography'),
+						'font_style'		=>  __("Font Style",'acf-typography'),
+						'font_variant'		=>  __("Font Variant",'acf-typography'),
+						'font_stretch'		=>  __("Font Stretch",'acf-typography'),
+						'line_height'		=>  __("Line Height",'acf-typography'),
+						'letter_spacing'	=>  __("Letter Spacing",'acf-typography'),
+						'text_align'		=>  __("Text Align",'acf-typography'),
+						'text_color'		=>  __("Text Color",'acf-typography'),
+						'text_decoration'	=>  __("Text Decoration",'acf-typography'),
+						'text_transform'	=>  __("Text Transform",'acf-typography'),
 					),
 					'layout'    =>  'horizontal',
 				));
@@ -210,22 +210,22 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'      =>  'checkbox',
-					'name'      =>  'fields['.$key.'][required_properties]',
-					'value'     =>  $field['required_properties'],
-					'choices'   =>  array(
-						'font_size'         =>  __("Font Size",'acf-typography'),
-						'font_family'       =>  __("Font Family",'acf-typography'),
-						'font_weight'       =>  __("Font Weight",'acf-typography'),
-						'font_style'        =>  __("Font Style",'acf-typography'),
-                                                'font_variant'      =>  __("Font Variant",'acf-typography'),
-                                                'font_stretch'      =>  __("Font Stretch",'acf-typography'),
-						'line_height'       =>  __("Line Height",'acf-typography'),
-						'letter_spacing'    =>  __("Letter Spacing",'acf-typography'),
-						'text_align'        =>  __("Text Align",'acf-typography'),
-						'text_color'        =>  __("Text Color",'acf-typography'),
-						'text_decoration'   =>  __("Text Decoration",'acf-typography'),
-						'text_transform'    =>  __("Text Transform",'acf-typography'),
+					'type'		=>  'checkbox',
+					'name'		=>  'fields['.$key.'][required_properties]',
+					'value'		=>  $field['required_properties'],
+					'choices'	=>  array(
+						'font_size'			=>  __("Font Size",'acf-typography'),
+						'font_family'		=>  __("Font Family",'acf-typography'),
+						'font_weight'		=>  __("Font Weight",'acf-typography'),
+						'font_style'		=>  __("Font Style",'acf-typography'),
+						'font_variant'		=>  __("Font Variant",'acf-typography'),
+						'font_stretch'		=>  __("Font Stretch",'acf-typography'),
+						'line_height'		=>  __("Line Height",'acf-typography'),
+						'letter_spacing'	=>  __("Letter Spacing",'acf-typography'),
+						'text_align'		=>  __("Text Align",'acf-typography'),
+						'text_color'		=>  __("Text Color",'acf-typography'),
+						'text_decoration'	=>  __("Text Decoration",'acf-typography'),
+						'text_transform'	=>  __("Text Transform",'acf-typography'),
 					),
 					'layout'    =>  'horizontal',
 				));
@@ -240,10 +240,10 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'      =>  'number',
-					'name'      =>  'fields['.$key.'][font_size]',
-					'value'     =>  $field['font_size'],
-					'append'    =>  'px'
+					'type'		=>  'number',
+					'name'		=>  'fields['.$key.'][font_size]',
+					'value'		=>  $field['font_size'],
+					'append'	=>  'px'
 				));
 				?>
 			</td>
@@ -256,11 +256,11 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'      =>  'select',
-					'name'      =>  'fields['.$key.'][font_family]',
-					'value'     =>  $field['font_family'],
-					'choices'   =>  $this->font_family,
-					'layout'    =>  'horizontal',
+					'type'		=>  'select',
+					'name'		=>  'fields['.$key.'][font_family]',
+					'value'		=>  $field['font_family'],
+					'choices'	=>  $this->font_family,
+					'layout'	=>  'horizontal',
 				));
 				?>
 			</td>
@@ -273,11 +273,11 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'      =>  'select',
-					'name'      =>  'fields['.$key.'][font_weight]',
-					'value'     =>  $field['font_weight'],
-					'choices'   =>  $this->font_weight,
-					'layout'    =>  'horizontal',
+					'type'		=>  'select',
+					'name'		=>  'fields['.$key.'][font_weight]',
+					'value'		=>  $field['font_weight'],
+					'choices'	=>  $this->font_weight,
+					'layout'	=>  'horizontal',
 				));
 				?>
 			</td>
@@ -290,12 +290,12 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'      =>  'select',
-					'name'      =>  'fields['.$key.'][font_style]',
-					'value'     =>  $field['font_style'],
-					'ui'        =>  1,
-					'choices'   =>  $this->font_style,
-					'layout'    =>  'horizontal',
+					'type'		=>  'select',
+					'name'		=>  'fields['.$key.'][font_style]',
+					'value'		=>  $field['font_style'],
+					'ui'		=>  1,
+					'choices'	=>  $this->font_style,
+					'layout'	=>  'horizontal',
 				));
 				?>
 			</td>
@@ -308,12 +308,12 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'      =>  'select',
-					'name'      =>  'fields['.$key.'][font_variant]',
-					'value'     =>  $field['font_variant'],
-					'ui'        =>  1,
-					'choices'   =>  $this->font_variant,
-					'layout'    =>  'horizontal',
+					'type'		=>  'select',
+					'name'		=>  'fields['.$key.'][font_variant]',
+					'value'		=>  $field['font_variant'],
+					'ui'		=>  1,
+					'choices'	=>  $this->font_variant,
+					'layout'	=>  'horizontal',
 				));
 				?>
 			</td>
@@ -326,12 +326,12 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'      =>  'select',
-					'name'      =>  'fields['.$key.'][font_stretch]',
-					'value'     =>  $field['font_stretch'],
-					'ui'        =>  1,
-					'choices'   =>  $this->font_stretch,
-					'layout'    =>  'horizontal',
+					'type'		=>  'select',
+					'name'		=>  'fields['.$key.'][font_stretch]',
+					'value'		=>  $field['font_stretch'],
+					'ui'		=>  1,
+					'choices'	=>  $this->font_stretch,
+					'layout'	=>  'horizontal',
 				));
 				?>
 			</td>
@@ -344,10 +344,10 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'      =>  'number',
-					'name'      =>  'fields['.$key.'][line_height]',
-					'value'     =>  $field['line_height'],
-					'append'    =>  'px'
+					'type'		=>  'number',
+					'name'		=>  'fields['.$key.'][line_height]',
+					'value'		=>  $field['line_height'],
+					'append'	=>  'px'
 				));
 				?>
 			</td>
@@ -360,10 +360,10 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'      =>  'number',
-					'name'      =>  'fields['.$key.'][letter_spacing]',
-					'value'     =>  $field['letter_spacing'],
-					'append'    =>  'px'
+					'type'		=>  'number',
+					'name'		=>  'fields['.$key.'][letter_spacing]',
+					'value'		=>  $field['letter_spacing'],
+					'append'	=>  'px'
 				));
 				?>
 			</td>
@@ -376,12 +376,12 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'      =>  'select',
-					'name'      =>  'fields['.$key.'][text_align]',
-					'value'     =>  $field['text_align'],
-					'ui'        =>  1,
-					'choices'   =>  $this->text_align,
-					'layout'    =>  'horizontal',
+					'type'		=>  'select',
+					'name'		=>  'fields['.$key.'][text_align]',
+					'value'		=>  $field['text_align'],
+					'ui'		=>  1,
+					'choices'	=>  $this->text_align,
+					'layout'	=>  'horizontal',
 				));
 				?>
 			</td>
@@ -394,9 +394,9 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'  =>  'text',
-					'name'  =>  'fields['.$key.'][text_color]',
-					'value' =>  $field['text_color'],
+					'type'	=>  'text',
+					'name'	=>  'fields['.$key.'][text_color]',
+					'value'	=>  $field['text_color'],
 				));
 				?>
 			</td>
@@ -409,12 +409,12 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'      =>  'select',
-					'name'      =>  'fields['.$key.'][text_decoration]',
-					'value'     =>  $field['text_decoration'],
-					'ui'        =>  1,
-					'choices'   =>  $this->text_decoration,
-					'layout'    =>  'horizontal',
+					'type'		=>  'select',
+					'name'		=>  'fields['.$key.'][text_decoration]',
+					'value'		=>  $field['text_decoration'],
+					'ui'		=>  1,
+					'choices'	=>  $this->text_decoration,
+					'layout'	=>  'horizontal',
 				));
 				?>
 			</td>
@@ -427,12 +427,12 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'      =>  'select',
-					'name'      =>  'fields['.$key.'][text_transform]',
-					'value'     =>  $field['text_transform'],
-					'ui'        =>  1,
-					'choices'   =>  $this->text_transform,
-					'layout'    =>  'horizontal',
+					'type'		=>  'select',
+					'name'		=>  'fields['.$key.'][text_transform]',
+					'value'		=>  $field['text_transform'],
+					'ui'		=>  1,
+					'choices'	=>  $this->text_transform,
+					'layout'	=>  'horizontal',
 				));
 				?>
 			</td>
@@ -484,8 +484,6 @@ class acf_field_Typography extends acf_field {
 				}
 				
 				if( in_array($f, $numbers) ){ ?>
-                
-                
 					<div id="acf-<?php echo $f; ?>" class="field field_type-number field_key-<?php echo $key; ?> <?php echo $required; ?>" data-field_name="<?php echo $f; ?>" data-field_key="<?php echo $key; ?>" data-field_type="number">
 						<p class="label">
 							<label for="acf-field-<?php echo $f; ?>">
@@ -496,22 +494,17 @@ class acf_field_Typography extends acf_field {
 							
 							</label>
 						</p>
-
 						<?php
 							do_action('acf/create_field', array(
-								'type'      =>  'number',
-								'name'      =>  $field['name'].'['.$f.']',
-								'value'     =>  ( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] ),
-								'id'        =>  'acf-field-'.$f,
-								'append'    =>  'px'
+								'type'		=>  'number',
+								'name'		=>  $field['name'].'['.$f.']',
+								'value'		=>  ( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] ),
+								'id'		=>  'acf-field-'.$f,
+								'append'	=>  'px'
 							));
 						?>
 					</div>
-                
-                
 				<?php }else if( in_array($f, $selects) ){ ?>
-                
-                
 					<div id="acf-<?php echo $f; ?>" class="field field_type-select field_key-<?php echo $key; ?> <?php echo $required; ?>" data-field_name="<?php echo $f; ?>" data-field_key="<?php echo $key; ?>" data-field_type="select">
 						<p class="label">
 							<label for="acf-field-<?php echo $f; ?>">
@@ -521,7 +514,6 @@ class acf_field_Typography extends acf_field {
 								<?php } ?>
 							</label>
 						</p>
-
 						<select id="acf-field-<?php echo $f; ?>" class="select" name="<?php echo $field['name'].'['.$f.']'; ?>">
 							<?php 
 								$options = '';
@@ -533,14 +525,9 @@ class acf_field_Typography extends acf_field {
 								}
 								echo $options;
 							?>
-
 						</select>
 					</div>
-                
-                
 				<?php }else{ ?>
-                
-                
 					<div id="acf-<?php echo $f; ?>" class="field field_type-text field_key-<?php echo $key; ?> <?php echo $required; ?> acf-color_picker" data-field_name="<?php echo $f; ?>" data-field_key="<?php echo $key; ?>" data-field_type="text">
 						<p class="label">
 							<label for="acf-field-<?php echo $f; ?>">
@@ -550,18 +537,15 @@ class acf_field_Typography extends acf_field {
 								<?php } ?>
 							</label>
 						</p>
-
 						<?php
 							do_action('acf/create_field', array(
-								'type'  =>  'text',
-								'name'  =>  $field['name'].'['.$f.']',
-								'value' =>  ( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] ),
-								'id'    =>  'acf-field-'.$f,
+								'type'	=>  'text',
+								'name'	=>  $field['name'].'['.$f.']',
+								'value'	=>  ( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] ),
+								'id'	=>  'acf-field-'.$f,
 							));
 						?>
 					</div>
-                
-                
 				<?php 
 					}
 			}

--- a/fields/acf-Typography-v4.php
+++ b/fields/acf-Typography-v4.php
@@ -12,7 +12,7 @@ class acf_field_Typography extends acf_field {
 	
 	// vars
 	var $settings, // will hold info such as dir / path
-		$defaults; // will hold default field options
+            $defaults; // will hold default field options
 		
 		
 	/*
@@ -35,17 +35,17 @@ class acf_field_Typography extends acf_field {
 			// This makes life easy when creating the field options as you don't need to use any if( isset('') ) logic. eg:
 			'display_properties'	=> array(),
 			'required_properties'	=> array(),
-			'font_size'				=> 15,
-			'font_weight'			=> '400',
-			'font_family'			=> 'Arial, Helvetica, sans-serif',
-			'font_style'			=> 'normal',
-            'font_variant'			=> 'normal',
-            'font_stretch'			=> 'normal',
-			'text_align'			=> 'left',
-			'letter_spacing'		=> 0,
-			'text_decoration'		=> 'none',
-			'text_color'			=> '#000',
-			'text_transform'		=> 'none'
+			'font_size'		=> 15,
+			'font_weight'		=> '400',
+			'font_family'		=> 'Arial, Helvetica, sans-serif',
+			'font_style'		=> 'normal',
+                        'font_variant'		=> 'normal',
+                        'font_stretch'		=> 'normal',
+			'text_align'		=> 'left',
+			'letter_spacing'	=> 0,
+			'text_decoration'	=> 'none',
+			'text_color'		=> '#000',
+			'text_transform'	=> 'none'
 		);
 		
 		$this->font_family = array(
@@ -77,8 +77,8 @@ class acf_field_Typography extends acf_field {
 		// sort array by array key
 		ksort( $this->font_family );
         
-        // add 'initial' and 'inherit' property values to top of the array
-        $this->font_family = array_merge( array( 'initial' => 'initial', 'inherit' => 'inherit' ), $this->font_family );
+                // add 'initial' and 'inherit' property values to top of the array
+                $this->font_family = array_merge( array( 'initial' => 'initial', 'inherit' => 'inherit' ), $this->font_family );
 		
 		$this->font_weight = array(
 			'100'		=> '100',
@@ -96,11 +96,11 @@ class acf_field_Typography extends acf_field {
 			'italic'	=> 'italic',
 			'oblique'	=> 'oblique',
 		);
-        $this->font_variant = array(
+                $this->font_variant = array(
 			'normal'     => 'normal',
-            'small-caps' => 'small-caps',
-            'initial'    => 'initial',
-            'inherit'    => 'inherit'
+                        'small-caps' => 'small-caps',
+                        'initial'    => 'initial',
+                        'inherit'    => 'inherit'
 		);
 		$this->font_stretch = array(
 			'ultra-condensed'   => 'ultra-condensed',
@@ -124,20 +124,20 @@ class acf_field_Typography extends acf_field {
 			'initial'	=> 'initial'
 		);
 		$this->text_decoration = array(
-			'none' 			=> 'none',
+			'none' 		=> 'none',
 			'underline' 	=> 'underline',
-			'overline' 		=> 'overline',
+			'overline' 	=> 'overline',
 			'line-through' 	=> 'line-through',
-			'initial' 		=> 'initial',
-			'inherit' 		=> 'inherit'
+			'initial' 	=> 'initial',
+			'inherit' 	=> 'inherit'
 		);
 		$this->text_transform = array(
-			'none' 			=> 'none',
+			'none' 		=> 'none',
 			'capitalize' 	=> 'capitalize',
 			'uppercase' 	=> 'uppercase',
 			'lowercase' 	=> 'lowercase',
-			'initial' 		=> 'initial',
-			'inherit' 		=> 'inherit'
+			'initial' 	=> 'initial',
+			'inherit' 	=> 'inherit'
 		);
 		
 		
@@ -180,24 +180,24 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'  =>  'checkbox',
-					'name'  =>  'fields['.$key.'][display_properties]',
-					'value' =>  $field['display_properties'],
-					'choices' =>  array(
-						'font_size' =>  __("Font Size",'acf-typography'),
-						'font_family' =>  __("Font Family",'acf-typography'),
-						'font_weight' =>  __("Font Weight",'acf-typography'),
-						'font_style' =>  __("Font Style",'acf-typography'),
-                        'font_variant' =>  __("Font Variant",'acf-typography'),
-                        'font_stretch' =>  __("Font Stretch",'acf-typography'),
-						'line_height' =>  __("Line Height",'acf-typography'),
-						'letter_spacing' =>  __("Letter Spacing",'acf-typography'),
-						'text_align' =>  __("Text Align",'acf-typography'),
-						'text_color' =>  __("Text Color",'acf-typography'),
-						'text_decoration' =>  __("Text Decoration",'acf-typography'),
-						'text_transform' =>  __("Text Transform",'acf-typography'),
+					'type'      =>  'checkbox',
+					'name'      =>  'fields['.$key.'][display_properties]',
+					'value'     =>  $field['display_properties'],
+					'choices'   =>  array(
+						'font_size'         =>  __("Font Size",'acf-typography'),
+						'font_family'       =>  __("Font Family",'acf-typography'),
+						'font_weight'       =>  __("Font Weight",'acf-typography'),
+						'font_style'        =>  __("Font Style",'acf-typography'),
+                                                'font_variant'      =>  __("Font Variant",'acf-typography'),
+                                                'font_stretch'      =>  __("Font Stretch",'acf-typography'),
+						'line_height'       =>  __("Line Height",'acf-typography'),
+						'letter_spacing'    =>  __("Letter Spacing",'acf-typography'),
+						'text_align'        =>  __("Text Align",'acf-typography'),
+						'text_color'        =>  __("Text Color",'acf-typography'),
+						'text_decoration'   =>  __("Text Decoration",'acf-typography'),
+						'text_transform'    =>  __("Text Transform",'acf-typography'),
 					),
-					'layout'  =>  'horizontal',
+					'layout'    =>  'horizontal',
 				));
 				?>
 			</td>
@@ -210,24 +210,24 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'  =>  'checkbox',
-					'name'  =>  'fields['.$key.'][required_properties]',
-					'value' =>  $field['required_properties'],
-					'choices' =>  array(
-						'font_size' =>  __("Font Size",'acf-typography'),
-						'font_family' =>  __("Font Family",'acf-typography'),
-						'font_weight' =>  __("Font Weight",'acf-typography'),
-						'font_style' =>  __("Font Style",'acf-typography'),
-                        'font_variant' =>  __("Font Variant",'acf-typography'),
-                        'font_stretch' =>  __("Font Stretch",'acf-typography'),
-						'line_height' =>  __("Line Height",'acf-typography'),
-						'letter_spacing' =>  __("Letter Spacing",'acf-typography'),
-						'text_align' =>  __("Text Align",'acf-typography'),
-						'text_color' =>  __("Text Color",'acf-typography'),
-						'text_decoration' =>  __("Text Decoration",'acf-typography'),
-						'text_transform' =>  __("Text Transform",'acf-typography'),
+					'type'      =>  'checkbox',
+					'name'      =>  'fields['.$key.'][required_properties]',
+					'value'     =>  $field['required_properties'],
+					'choices'   =>  array(
+						'font_size'         =>  __("Font Size",'acf-typography'),
+						'font_family'       =>  __("Font Family",'acf-typography'),
+						'font_weight'       =>  __("Font Weight",'acf-typography'),
+						'font_style'        =>  __("Font Style",'acf-typography'),
+                                                'font_variant'      =>  __("Font Variant",'acf-typography'),
+                                                'font_stretch'      =>  __("Font Stretch",'acf-typography'),
+						'line_height'       =>  __("Line Height",'acf-typography'),
+						'letter_spacing'    =>  __("Letter Spacing",'acf-typography'),
+						'text_align'        =>  __("Text Align",'acf-typography'),
+						'text_color'        =>  __("Text Color",'acf-typography'),
+						'text_decoration'   =>  __("Text Decoration",'acf-typography'),
+						'text_transform'    =>  __("Text Transform",'acf-typography'),
 					),
-					'layout'  =>  'horizontal',
+					'layout'    =>  'horizontal',
 				));
 				?>
 			</td>
@@ -240,10 +240,10 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'  =>  'number',
-					'name'  =>  'fields['.$key.'][font_size]',
-					'value' =>  $field['font_size'],
-					'append' => 'px'
+					'type'      =>  'number',
+					'name'      =>  'fields['.$key.'][font_size]',
+					'value'     =>  $field['font_size'],
+					'append'    =>  'px'
 				));
 				?>
 			</td>
@@ -256,11 +256,11 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'  =>  'select',
-					'name'  =>  'fields['.$key.'][font_family]',
-					'value' =>  $field['font_family'],
-					'choices' =>  $this->font_family,
-					'layout'  =>  'horizontal',
+					'type'      =>  'select',
+					'name'      =>  'fields['.$key.'][font_family]',
+					'value'     =>  $field['font_family'],
+					'choices'   =>  $this->font_family,
+					'layout'    =>  'horizontal',
 				));
 				?>
 			</td>
@@ -273,11 +273,11 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'  =>  'select',
-					'name'  =>  'fields['.$key.'][font_weight]',
-					'value' =>  $field['font_weight'],
-					'choices' =>  $this->font_weight,
-					'layout'  =>  'horizontal',
+					'type'      =>  'select',
+					'name'      =>  'fields['.$key.'][font_weight]',
+					'value'     =>  $field['font_weight'],
+					'choices'   =>  $this->font_weight,
+					'layout'    =>  'horizontal',
 				));
 				?>
 			</td>
@@ -290,17 +290,17 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'  =>  'select',
-					'name'  =>  'fields['.$key.'][font_style]',
-					'value' =>  $field['font_style'],
-					'ui'	=> 1,
-					'choices' =>  $this->font_style,
-					'layout'  =>  'horizontal',
+					'type'      =>  'select',
+					'name'      =>  'fields['.$key.'][font_style]',
+					'value'     =>  $field['font_style'],
+					'ui'        =>  1,
+					'choices'   =>  $this->font_style,
+					'layout'    =>  'horizontal',
 				));
 				?>
 			</td>
 		</tr>
-        <tr class="field_option field_option_<?php echo $this->name; ?>">
+                <tr class="field_option field_option_<?php echo $this->name; ?>">
 			<td class="label">
 				<label><?php _e("Font Variant",'acf-typography'); ?></label>
 				<p class="description"><?php _e('(Default)', 'acf-typography'); ?></p>
@@ -308,12 +308,12 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'  =>  'select',
-					'name'  =>  'fields['.$key.'][font_variant]',
-					'value' =>  $field['font_variant'],
-					'ui'	=> 1,
-					'choices' =>  $this->font_variant,
-					'layout'  =>  'horizontal',
+					'type'      =>  'select',
+					'name'      =>  'fields['.$key.'][font_variant]',
+					'value'     =>  $field['font_variant'],
+					'ui'        =>  1,
+					'choices'   =>  $this->font_variant,
+					'layout'    =>  'horizontal',
 				));
 				?>
 			</td>
@@ -326,12 +326,12 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'  =>  'select',
-					'name'  =>  'fields['.$key.'][font_stretch]',
-					'value' =>  $field['font_stretch'],
-					'ui'	=> 1,
-					'choices' =>  $this->font_stretch,
-					'layout'  =>  'horizontal',
+					'type'      =>  'select',
+					'name'      =>  'fields['.$key.'][font_stretch]',
+					'value'     =>  $field['font_stretch'],
+					'ui'        =>  1,
+					'choices'   =>  $this->font_stretch,
+					'layout'    =>  'horizontal',
 				));
 				?>
 			</td>
@@ -344,10 +344,10 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'  =>  'number',
-					'name'  =>  'fields['.$key.'][line_height]',
-					'value' =>  $field['line_height'],
-					'append' => 'px'
+					'type'      =>  'number',
+					'name'      =>  'fields['.$key.'][line_height]',
+					'value'     =>  $field['line_height'],
+					'append'    =>  'px'
 				));
 				?>
 			</td>
@@ -360,10 +360,10 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'  =>  'number',
-					'name'  =>  'fields['.$key.'][letter_spacing]',
-					'value' =>  $field['letter_spacing'],
-					'append' => 'px'
+					'type'      =>  'number',
+					'name'      =>  'fields['.$key.'][letter_spacing]',
+					'value'     =>  $field['letter_spacing'],
+					'append'    =>  'px'
 				));
 				?>
 			</td>
@@ -376,12 +376,12 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'  =>  'select',
-					'name'  =>  'fields['.$key.'][text_align]',
-					'value' =>  $field['text_align'],
-					'ui'	=> 1,
-					'choices' =>  $this->text_align,
-					'layout'  =>  'horizontal',
+					'type'      =>  'select',
+					'name'      =>  'fields['.$key.'][text_align]',
+					'value'     =>  $field['text_align'],
+					'ui'        =>  1,
+					'choices'   =>  $this->text_align,
+					'layout'    =>  'horizontal',
 				));
 				?>
 			</td>
@@ -409,12 +409,12 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'  =>  'select',
-					'name'  =>  'fields['.$key.'][text_decoration]',
-					'value' =>  $field['text_decoration'],
-					'ui'	=> 1,
-					'choices' => $this->text_decoration,
-					'layout'  =>  'horizontal',
+					'type'      =>  'select',
+					'name'      =>  'fields['.$key.'][text_decoration]',
+					'value'     =>  $field['text_decoration'],
+					'ui'        =>  1,
+					'choices'   =>  $this->text_decoration,
+					'layout'    =>  'horizontal',
 				));
 				?>
 			</td>
@@ -427,12 +427,12 @@ class acf_field_Typography extends acf_field {
 			<td>
 				<?php
 				do_action('acf/create_field', array(
-					'type'  =>  'select',
-					'name'  =>  'fields['.$key.'][text_transform]',
-					'value' =>  $field['text_transform'],
-					'ui'	=> 1,
-					'choices' => $this->text_transform,
-					'layout'  =>  'horizontal',
+					'type'      =>  'select',
+					'name'      =>  'fields['.$key.'][text_transform]',
+					'value'     =>  $field['text_transform'],
+					'ui'        =>  1,
+					'choices'   =>  $this->text_transform,
+					'layout'    =>  'horizontal',
 				));
 				?>
 			</td>
@@ -484,6 +484,8 @@ class acf_field_Typography extends acf_field {
 				}
 				
 				if( in_array($f, $numbers) ){ ?>
+                
+                
 					<div id="acf-<?php echo $f; ?>" class="field field_type-number field_key-<?php echo $key; ?> <?php echo $required; ?>" data-field_name="<?php echo $f; ?>" data-field_key="<?php echo $key; ?>" data-field_type="number">
 						<p class="label">
 							<label for="acf-field-<?php echo $f; ?>">
@@ -497,15 +499,19 @@ class acf_field_Typography extends acf_field {
 
 						<?php
 							do_action('acf/create_field', array(
-								'type'  =>  'number',
-								'name'  =>  $field['name'].'['.$f.']',
-								'value' =>  ( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] ),
-								'id' => 'acf-field-'.$f,
-								'append' => 'px'
+								'type'      =>  'number',
+								'name'      =>  $field['name'].'['.$f.']',
+								'value'     =>  ( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] ),
+								'id'        =>  'acf-field-'.$f,
+								'append'    =>  'px'
 							));
 						?>
 					</div>
+                
+                
 				<?php }else if( in_array($f, $selects) ){ ?>
+                
+                
 					<div id="acf-<?php echo $f; ?>" class="field field_type-select field_key-<?php echo $key; ?> <?php echo $required; ?>" data-field_name="<?php echo $f; ?>" data-field_key="<?php echo $key; ?>" data-field_type="select">
 						<p class="label">
 							<label for="acf-field-<?php echo $f; ?>">
@@ -530,7 +536,11 @@ class acf_field_Typography extends acf_field {
 
 						</select>
 					</div>
+                
+                
 				<?php }else{ ?>
+                
+                
 					<div id="acf-<?php echo $f; ?>" class="field field_type-text field_key-<?php echo $key; ?> <?php echo $required; ?> acf-color_picker" data-field_name="<?php echo $f; ?>" data-field_key="<?php echo $key; ?>" data-field_type="text">
 						<p class="label">
 							<label for="acf-field-<?php echo $f; ?>">
@@ -546,15 +556,16 @@ class acf_field_Typography extends acf_field {
 								'type'  =>  'text',
 								'name'  =>  $field['name'].'['.$f.']',
 								'value' =>  ( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] ),
-								'id' => 'acf-field-'.$f,
+								'id'    =>  'acf-field-'.$f,
 							));
 						?>
 					</div>
+                
+                
 				<?php 
 					}
 			}
 		}
-	
 	}
 	
 	

--- a/fields/acf-Typography-v5.php
+++ b/fields/acf-Typography-v5.php
@@ -11,7 +11,7 @@ if( !class_exists('acf_field_Typography') ) :
 class acf_field_Typography extends acf_field {
 	
 	// declare vars instead of assigning dynamically for php8.2 compatibility (deprecated dynamic properties)
-    var array $settings, $font_family, $font_weight, $font_style, $font_variant, $font_stretch, $text_align, $text_decoration, $text_transform;
+    var $settings, $font_family, $font_weight, $font_style, $font_variant, $font_stretch, $text_align, $text_decoration, $text_transform;
 	
 	/*
 	*  __construct

--- a/fields/acf-Typography-v5.php
+++ b/fields/acf-Typography-v5.php
@@ -10,6 +10,8 @@ if( !class_exists('acf_field_Typography') ) :
 
 class acf_field_Typography extends acf_field {
 	
+	// declare vars instead of assigning dynamically for php8.2 compatibility (deprecated dynamic properties)
+    var array $settings, $font_family, $font_weight, $font_style, $font_variant, $font_stretch, $text_align, $text_decoration, $text_transform;
 	
 	/*
 	*  __construct

--- a/fields/acf-Typography-v5.php
+++ b/fields/acf-Typography-v5.php
@@ -54,17 +54,17 @@ class acf_field_Typography extends acf_field {
 		$this->defaults = array(
 			'display_properties'	=> array(),
 			'required_properties'	=> array(),
-			'font_size'				=> 15,
-			'font_weight'			=> '400',
-			'font_family'			=> 'Arial, Helvetica, sans-serif',
-			'font_style'			=> 'normal',
-            'font_variant'			=> 'normal',
-            'font_stretch'			=> 'normal',
-			'text_align'			=> 'left',
-			'letter_spacing'		=> 0,
-			'text_decoration'		=> 'none',
-			'text_color'			=> '#000',
-			'text_transform'		=> 'none'
+			'font_size'             => 15,
+			'font_weight'		=> '400',
+			'font_family'		=> 'Arial, Helvetica, sans-serif',
+			'font_style'		=> 'normal',
+                        'font_variant'		=> 'normal',
+                        'font_stretch'		=> 'normal',
+			'text_align'		=> 'left',
+			'letter_spacing'	=> 0,
+			'text_decoration'	=> 'none',
+			'text_color'		=> '#000',
+			'text_transform'	=> 'none'
 		);
 		
 		$this->font_family = array(
@@ -96,8 +96,8 @@ class acf_field_Typography extends acf_field {
 		// sort array by array key
 		ksort( $this->font_family );
         
-        // add 'initial' and 'inherit' property values to top of the array
-        $this->font_family = array_merge( array( 'initial' => 'initial', 'inherit' => 'inherit' ), $this->font_family );
+                // add 'initial' and 'inherit' property values to top of the array
+                $this->font_family = array_merge( array( 'initial' => 'initial', 'inherit' => 'inherit' ), $this->font_family );
 		
 		$this->font_weight = array(
 			'100'		=> '100',
@@ -115,11 +115,11 @@ class acf_field_Typography extends acf_field {
 			'italic'	=> 'italic',
 			'oblique'	=> 'oblique',
 		);
-        $this->font_variant = array(
+                $this->font_variant = array(
 			'normal'     => 'normal',
-            'small-caps' => 'small-caps',
-            'initial'    => 'initial',
-            'inherit'    => 'inherit'
+                        'small-caps' => 'small-caps',
+                        'initial'    => 'initial',
+                        'inherit'    => 'inherit'
 		);
 		$this->font_stretch = array(
 			'ultra-condensed'   => 'ultra-condensed',
@@ -143,20 +143,20 @@ class acf_field_Typography extends acf_field {
 			'initial'	=> 'initial'
 		);
 		$this->text_decoration = array(
-			'none' 			=> 'none',
+			'none' 		=> 'none',
 			'underline' 	=> 'underline',
-			'overline' 		=> 'overline',
+			'overline' 	=> 'overline',
 			'line-through' 	=> 'line-through',
-			'initial' 		=> 'initial',
-			'inherit' 		=> 'inherit'
+			'initial' 	=> 'initial',
+			'inherit' 	=> 'inherit'
 		);
 		$this->text_transform = array(
-			'none' 			=> 'none',
+			'none' 		=> 'none',
 			'capitalize' 	=> 'capitalize',
 			'uppercase' 	=> 'uppercase',
 			'lowercase' 	=> 'lowercase',
-			'initial' 		=> 'initial',
-			'inherit' 		=> 'inherit'
+			'initial' 	=> 'initial',
+			'inherit' 	=> 'inherit'
 		);
 		
 		
@@ -209,148 +209,148 @@ class acf_field_Typography extends acf_field {
 		*/
 		
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Display Properties','acf-typography'),
+			'label'		=> __('Display Properties','acf-typography'),
 			'instructions'	=> __('Select fields to display on edit page','acf-typography'),
-			'type'			=> 'checkbox',
-			'name'			=> 'display_properties',
-			'choices' =>  array(
-				'font_size' =>  __("Font Size",'acf-typography'),
-				'font_family' =>  __("Font Family",'acf-typography'),
-				'font_weight' =>  __("Font Weight",'acf-typography'),
-				'font_style' =>  __("Font Style",'acf-typography'),
-                'font_variant' =>  __("Font Variant",'acf-typography'),
-                'font_stretch' =>  __("Font Stretch",'acf-typography'),
-				'line_height' =>  __("Line Height",'acf-typography'),
-				'letter_spacing' =>  __("Letter Spacing",'acf-typography'),
-				'text_align' =>  __("Text Align",'acf-typography'),
-				'text_color' =>  __("Text Color",'acf-typography'),
-				'text_decoration' =>  __("Text Decoration",'acf-typography'),
-				'text_transform' =>  __("Text Transform",'acf-typography'),
+			'type'		=> 'checkbox',
+			'name'		=> 'display_properties',
+			'choices'       =>  array(
+				'font_size'         =>  __("Font Size",'acf-typography'),
+				'font_family'       =>  __("Font Family",'acf-typography'),
+				'font_weight'       =>  __("Font Weight",'acf-typography'),
+				'font_style'        =>  __("Font Style",'acf-typography'),
+                                'font_variant'      =>  __("Font Variant",'acf-typography'),
+                                'font_stretch'      =>  __("Font Stretch",'acf-typography'),
+				'line_height'       =>  __("Line Height",'acf-typography'),
+				'letter_spacing'    =>  __("Letter Spacing",'acf-typography'),
+				'text_align'        =>  __("Text Align",'acf-typography'),
+				'text_color'        =>  __("Text Color",'acf-typography'),
+				'text_decoration'   =>  __("Text Decoration",'acf-typography'),
+				'text_transform'    =>  __("Text Transform",'acf-typography'),
 			),
-			'layout'  =>  'horizontal',
+			'layout'        =>  'horizontal',
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Required Properties','acf-typography'),
+			'label'		=> __('Required Properties','acf-typography'),
 			'instructions'	=> __('Select fields which are required on edit page','acf-typography'),
-			'type'			=> 'checkbox',
-			'name'			=> 'required_properties',
-			'choices' =>  array(
-				'font_size' =>  __("Font Size",'acf-typography'),
-				'font_family' =>  __("Font Family",'acf-typography'),
-				'font_weight' =>  __("Font Weight",'acf-typography'),
-				'font_style' =>  __("Font Style",'acf-typography'),
-                'font_variant' =>  __("Font Variant",'acf-typography'),
-                'font_stretch' =>  __("Font Stretch",'acf-typography'),
-				'line_height' =>  __("Line Height",'acf-typography'),
-				'letter_spacing' =>  __("Letter Spacing",'acf-typography'),
-				'text_align' =>  __("Text Align",'acf-typography'),
-				'text_color' =>  __("Text Color",'acf-typography'),
-				'text_decoration' =>  __("Text Decoration",'acf-typography'),
-				'text_transform' =>  __("Text Transform",'acf-typography'),
+			'type'		=> 'checkbox',
+			'name'		=> 'required_properties',
+			'choices'       =>  array(
+				'font_size'         =>  __("Font Size",'acf-typography'),
+				'font_family'       =>  __("Font Family",'acf-typography'),
+				'font_weight'       =>  __("Font Weight",'acf-typography'),
+				'font_style'        =>  __("Font Style",'acf-typography'),
+                                'font_variant'      =>  __("Font Variant",'acf-typography'),
+                                'font_stretch'      =>  __("Font Stretch",'acf-typography'),
+				'line_height'       =>  __("Line Height",'acf-typography'),
+				'letter_spacing'    =>  __("Letter Spacing",'acf-typography'),
+				'text_align'        =>  __("Text Align",'acf-typography'),
+				'text_color'        =>  __("Text Color",'acf-typography'),
+				'text_decoration'   =>  __("Text Decoration",'acf-typography'),
+				'text_transform'    =>  __("Text Transform",'acf-typography'),
 			),
-			'layout'  =>  'horizontal',
+			'layout'        =>  'horizontal',
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Font Size','acf-typography'),
+			'label'		=> __('Font Size','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'			=> 'number',
-			'name'			=> 'font_size',
+			'type'		=> 'number',
+			'name'		=> 'font_size',
 			'append'        => 'px'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Font Family','acf-typography'),
+			'label'		=> __('Font Family','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'			=> 'select',
-			'name'			=> 'font_family',
+			'type'		=> 'select',
+			'name'		=> 'font_family',
 			'choices'       => $this->font_family,
 			'layout'        => 'horizontal'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Font Weight','acf-typography'),
+			'label'		=> __('Font Weight','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'			=> 'select',
-			'name'			=> 'font_weight',
+			'type'		=> 'select',
+			'name'		=> 'font_weight',
 			'choices'       => $this->font_weight,
 			'layout'        => 'horizontal'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Font Style','acf-typography'),
+			'label'		=> __('Font Style','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'			=> 'select',
-			'name'			=> 'font_style',
+			'type'		=> 'select',
+			'name'		=> 'font_style',
 			'choices'       => $this->font_style,
 			'layout'        => 'horizontal'
 		));
         
-        acf_render_field_setting( $field, array(
-			'label'			=> __('Font Variant','acf-typography'),
+                acf_render_field_setting( $field, array(
+			'label'		=> __('Font Variant','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'			=> 'select',
-			'name'			=> 'font_variant',
+			'type'		=> 'select',
+			'name'		=> 'font_variant',
 			'choices'       => $this->font_variant,
 			'layout'        => 'horizontal'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Font Stretch','acf-typography'),
+			'label'		=> __('Font Stretch','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'			=> 'select',
-			'name'			=> 'font_stretch',
+			'type'		=> 'select',
+			'name'		=> 'font_stretch',
 			'choices'       => $this->font_stretch,
 			'layout'        => 'horizontal'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Line Height','acf-typography'),
+			'label'		=> __('Line Height','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'			=> 'number',
-			'name'			=> 'line_height',
+			'type'		=> 'number',
+			'name'		=> 'line_height',
 			'append'        => 'px'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Letter Spacing','acf-typography'),
+			'label'		=> __('Letter Spacing','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'			=> 'number',
-			'name'			=> 'letter_spacing',
+			'type'		=> 'number',
+			'name'		=> 'letter_spacing',
 			'append'        => 'px'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Text Align','acf-typography'),
+			'label'		=> __('Text Align','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'			=> 'select',
-			'name'			=> 'text_align',
+			'type'		=> 'select',
+			'name'		=> 'text_align',
 			'choices'       => $this->text_align,
 			'layout'        => 'horizontal'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Text Color','acf-typography'),
+			'label'		=> __('Text Color','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'			=> 'text',
-			'name'			=> 'text_color',
+                        'type'		=> 'color_picker', // changed from 'text' to 'color_picker' for v5 & v6 compatibility 
+			'name'		=> 'text_color',
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Text Decoration','acf-typography'),
+			'label'		=> __('Text Decoration','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'			=> 'select',
-			'name'			=> 'text_decoration',
+			'type'		=> 'select',
+			'name'		=> 'text_decoration',
 			'choices'       => $this->text_decoration,
 			'layout'        => 'horizontal'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'			=> __('Text Transform','acf-typography'),
+			'label'		=> __('Text Transform','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'			=> 'select',
-			'name'			=> 'text_transform',
+			'type'		=> 'select',
+			'name'		=> 'text_transform',
 			'choices'       => $this->text_transform,
 			'layout'        => 'horizontal'
 		));
@@ -393,26 +393,28 @@ class acf_field_Typography extends acf_field {
 		        
 		        $required = '';
 		        if( is_array($field['required_properties']) && in_array($f, $field['required_properties']) ){
-					$required = 'required';
-					$data_required = 'data-required="1"';
-				}
+                                $required = 'required';
+                                $data_required = 'data-required="1"';
+                        }
 				
-				if( $f == 'font_size' || $f == 'line_height' || $f == 'letter_spacing' ){
-					$numbers[] = $f;
-				}else if( $f == 'font_family' || $f == 'font_weight' || $f == 'font_style' || $f == 'font_variant' || $f == 'font_stretch' || $f == 'text_align' || $f == 'text_decoration' || $f == 'text_transform' ){
-					$selects[] = $f;
-				}
-				
-				if( in_array($f, $numbers) ){
-				?>
-				    <div class="acf-field acf-field-number acf-field-<?php echo $f; ?>" data-name="<?php echo $f; ?>" data-type="number" data-key="<?php echo $key; ?>" <?php echo $data_required; ?>>
+                        if( $f == 'font_size' || $f == 'line_height' || $f == 'letter_spacing' ){
+                                $numbers[] = $f;
+                        }else if( $f == 'font_family' || $f == 'font_weight' || $f == 'font_style' || $f == 'font_variant' || $f == 'font_stretch' || $f == 'text_align' || $f == 'text_decoration' || $f == 'text_transform' ){
+                                $selects[] = $f;
+                        }
+
+                        if( in_array($f, $numbers) ){
+                    ?>
+
+
+                    <div class="acf-field acf-field-number acf-field-<?php echo $f; ?>" data-name="<?php echo $f; ?>" data-type="number" data-key="<?php echo $key; ?>" <?php echo $data_required; ?>>
                     	<div class="acf-label">
                     		<label for="acf-field-<?php echo $f; ?>">
                     		    <?php echo __(ucwords(str_replace('_', ' ', $f)), 'acf-typography'); ?>
                     		    <?php if(!empty($required)){ ?>
-									<span class="acf-required">*</span></label>
-								<?php } ?>
-                    	</div>
+                                            <span class="acf-required">*</span></label>
+                                    <?php } ?>
+                    	</div>                            
                     	<div class="acf-input">
                     		<div class="acf-input-append">px</div>
                     		<div class="acf-input-wrap">
@@ -420,56 +422,64 @@ class acf_field_Typography extends acf_field {
                     		</div>
                     	</div>
                     </div>
-				<?php
-				}else  if( in_array($f, $selects) ){
-			    ?>
-			        <div class="acf-field acf-field-select acf-field-<?php echo $f; ?>" data-name="<?php echo $f; ?>" data-type="select" data-key="<?php echo $key; ?>" <?php echo $data_required; ?>>
+
+
+                    <?php
+                        }else  if( in_array($f, $selects) ){
+                    ?>
+
+
+                    <div class="acf-field acf-field-select acf-field-<?php echo $f; ?>" data-name="<?php echo $f; ?>" data-type="select" data-key="<?php echo $key; ?>" <?php echo $data_required; ?>>
                     	<div class="acf-label">
                     		<label for="acf-field-<?php echo $f; ?>">
                     		    <?php echo __(ucwords(str_replace('_', ' ', $f)), 'acf-typography'); ?>
                     		    <?php if(!empty($required)){ ?>
-									<span class="acf-required">*</span></label>
-								<?php } ?>
+                                            <span class="acf-required">*</span></label>
+                                    <?php } ?>
                     	</div>
                     	<div class="acf-input">
                     		<select id="acf-<?php echo $f; ?>" class="" name="<?php echo $field['name'].'['.$f.']'; ?>" data-ui="0" data-ajax="0" data-multiple="0" data-placeholder="Select" data-allow_null="0">
                     		    <?php 
-    								$options = '';
-    								foreach($this->$f as $opt){
-    									if( !empty($field['value'][$f]) )
-    										$options .= '<option val="'.$opt.'" '. ($field['value'][$f] == $opt? 'selected': '') .'>'.$opt.'</option>';
-    									else
-    										$options .= '<option val="'.$opt.'" '. ($field[$f] == $opt? 'selected': '') .'>'.$opt.'</option>';
-    								}
-    								echo $options;
-    							?>
+                                        $options = '';
+                                        foreach($this->$f as $opt){
+                                                if( !empty($field['value'][$f]) )
+                                                        $options .= '<option val="'.$opt.'" '. ($field['value'][$f] == $opt? 'selected': '') .'>'.$opt.'</option>';
+                                                else
+                                                        $options .= '<option val="'.$opt.'" '. ($field[$f] == $opt? 'selected': '') .'>'.$opt.'</option>';
+                                        }
+                                        echo $options;
+                                    ?>
                     		</select>
                     	</div>
                     </div>
-			    <?php
-				}else{
-			    ?>
-			    	<div class="acf-field acf-field-color-picker acf-field-<?php echo $f; ?>" data-name="<?php echo $f; ?>" data-type="color_picker" data-key="<?php echo $key; ?>" <?php echo $data_required; ?>>
+
+
+                    <?php
+                        }else{
+                    ?>
+
+
+                    <div class="acf-field acf-field-color-picker acf-field-<?php echo $f; ?>" data-name="<?php echo $f; ?>" data-type="color_picker" data-key="<?php echo $key; ?>" <?php echo $data_required; ?>>
                     	<div class="acf-label">
                     		<label for="acf-field-<?php echo $f; ?>">
                     		    <?php echo __(ucwords(str_replace('_', ' ', $f)), 'acf-typography'); ?>
                     		    <?php if(!empty($required)){ ?>
-									<span class="acf-required">*</span></label>
-								<?php } ?>
+                                            <span class="acf-required">*</span></label>
+                                    <?php } ?>
                     	</div>
                     	<div class="acf-input">
                     		<div class="acf-color_picker">
-								<input type="hidden" name="<?php echo esc_attr($field['name'].'['.$f.']') ?>" value="<?php echo esc_attr(( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] )) ?>">
-								<input type="text" id="<?php echo 'acf-field-'.$f; ?>" name="<?php echo esc_attr($field['name'].'['.$f.']') ?>" value="<?php echo esc_attr(( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] )) ?>">
-							</div>
+                                        <input type="hidden" name="<?php echo esc_attr($field['name'].'['.$f.']') ?>" value="<?php echo esc_attr(( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] )) ?>">
+                                        <input type="text" id="<?php echo 'acf-field-'.$f; ?>" name="<?php echo esc_attr($field['name'].'['.$f.']') ?>" value="<?php echo esc_attr(( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] )) ?>">
+                                </div>
                     	</div>
                     </div>
-			    <?php
-				}
+
+
+                    <?php
+                        }
 		    }
-		    
 		}
-		
 	}
 	
 		

--- a/fields/acf-Typography-v5.php
+++ b/fields/acf-Typography-v5.php
@@ -54,37 +54,37 @@ class acf_field_Typography extends acf_field {
 		$this->defaults = array(
 			'display_properties'	=> array(),
 			'required_properties'	=> array(),
-			'font_size'             => 15,
-			'font_weight'		=> '400',
-			'font_family'		=> 'Arial, Helvetica, sans-serif',
-			'font_style'		=> 'normal',
-                        'font_variant'		=> 'normal',
-                        'font_stretch'		=> 'normal',
-			'text_align'		=> 'left',
-			'letter_spacing'	=> 0,
-			'text_decoration'	=> 'none',
-			'text_color'		=> '#000',
-			'text_transform'	=> 'none'
+			'font_size'				=> 15,
+			'font_weight'			=> '400',
+			'font_family'			=> 'Arial, Helvetica, sans-serif',
+			'font_style'			=> 'normal',
+			'font_variant'			=> 'normal',
+			'font_stretch'			=> 'normal',
+			'text_align'			=> 'left',
+			'letter_spacing'		=> 0,
+			'text_decoration'		=> 'none',
+			'text_color'			=> '#000',
+			'text_transform'		=> 'none'
 		);
 		
 		$this->font_family = array(
-			'Arial, Helvetica, sans-serif'                          => 'Arial, Helvetica, sans-serif',
-			'"Arial Black", Gadget, sans-serif'                     => '"Arial Black", Gadget, sans-serif',
-			'"Bookman Old Style", serif'                            => '"Bookman Old Style", serif',
-			'"Comic Sans MS", cursive'                              => '"Comic Sans MS", cursive',
-			'Courier, monospace'                                    => 'Courier, monospace',
-			'Garamond, serif'                                       => 'Garamond, serif',
-			'Georgia, serif'                                        => 'Georgia, serif',
-			'Impact, Charcoal, sans-serif'                          => 'Impact, Charcoal, sans-serif',
-			'"Lucida Console", Monaco, monospace'                   => '"Lucida Console", Monaco, monospace',
-			'"Lucida Sans Unicode", "Lucida Grande", sans-serif'    => '"Lucida Sans Unicode", "Lucida Grande", sans-serif',
-			'"MS Sans Serif", Geneva, sans-serif'                   => '"MS Sans Serif", Geneva, sans-serif',
-			'"MS Serif", "New York", sans-serif'                    => '"MS Serif", "New York", sans-serif',
-			'"Palatino Linotype", "Book Antiqua", Palatino, serif'  => '"Palatino Linotype", "Book Antiqua", Palatino, serif',
-			'Tahoma,Geneva, sans-serif'                             => 'Tahoma, Geneva, sans-serif',
-			'"Times New Roman", Times,serif'                        => '"Times New Roman", Times, serif',
-			'"Trebuchet MS", Helvetica, sans-serif'                 => '"Trebuchet MS", Helvetica, sans-serif',
-			'Verdana, Geneva, sans-serif'                           => 'Verdana, Geneva, sans-serif',
+			'Arial, Helvetica, sans-serif'							=> 'Arial, Helvetica, sans-serif',
+			'"Arial Black", Gadget, sans-serif'						=> '"Arial Black", Gadget, sans-serif',
+			'"Bookman Old Style", serif'							=> '"Bookman Old Style", serif',
+			'"Comic Sans MS", cursive'								=> '"Comic Sans MS", cursive',
+			'Courier, monospace'									=> 'Courier, monospace',
+			'Garamond, serif'										=> 'Garamond, serif',
+			'Georgia, serif'										=> 'Georgia, serif',
+			'Impact, Charcoal, sans-serif'							=> 'Impact, Charcoal, sans-serif',
+			'"Lucida Console", Monaco, monospace'					=> '"Lucida Console", Monaco, monospace',
+			'"Lucida Sans Unicode", "Lucida Grande", sans-serif'	=> '"Lucida Sans Unicode", "Lucida Grande", sans-serif',
+			'"MS Sans Serif", Geneva, sans-serif'					=> '"MS Sans Serif", Geneva, sans-serif',
+			'"MS Serif", "New York", sans-serif'					=> '"MS Serif", "New York", sans-serif',
+			'"Palatino Linotype", "Book Antiqua", Palatino, serif'	=> '"Palatino Linotype", "Book Antiqua", Palatino, serif',
+			'Tahoma,Geneva, sans-serif'								=> 'Tahoma, Geneva, sans-serif',
+			'"Times New Roman", Times,serif'						=> '"Times New Roman", Times, serif',
+			'"Trebuchet MS", Helvetica, sans-serif'					=> '"Trebuchet MS", Helvetica, sans-serif',
+			'Verdana, Geneva, sans-serif'							=> 'Verdana, Geneva, sans-serif',
 		);
 
 		$google_font_family = acft_get_google_font_family(); // get google fonts from json file
@@ -95,9 +95,9 @@ class acf_field_Typography extends acf_field {
 
 		// sort array by array key
 		ksort( $this->font_family );
-        
-                // add 'initial' and 'inherit' property values to top of the array
-                $this->font_family = array_merge( array( 'initial' => 'initial', 'inherit' => 'inherit' ), $this->font_family );
+
+		// add 'initial' and 'inherit' property values to top of the array
+		$this->font_family = array_merge( array( 'initial' => 'initial', 'inherit' => 'inherit' ), $this->font_family );
 		
 		$this->font_weight = array(
 			'100'		=> '100',
@@ -115,24 +115,24 @@ class acf_field_Typography extends acf_field {
 			'italic'	=> 'italic',
 			'oblique'	=> 'oblique',
 		);
-                $this->font_variant = array(
-			'normal'     => 'normal',
-                        'small-caps' => 'small-caps',
-                        'initial'    => 'initial',
-                        'inherit'    => 'inherit'
+		$this->font_variant = array(
+			'normal'		=> 'normal',
+			'small-caps'	=> 'small-caps',
+			'initial'		=> 'initial',
+			'inherit'		=> 'inherit'
 		);
 		$this->font_stretch = array(
-			'ultra-condensed'   => 'ultra-condensed',
-			'extra-condensed'   => 'extra-condensed',
-			'condensed'         => 'condensed',
-			'semi-condensed'    => 'semi-condensed',
-			'normal'            => 'normal',
-			'semi-expanded'     => 'semi-expanded',
-			'expanded'          => 'expanded',
-			'extra-expanded'    => 'extra-expanded',
-			'ultra-expanded'    => 'ultra-expanded',
-			'initial'           => 'initial',
-			'inherit'           => 'inherit'
+			'ultra-condensed'	=> 'ultra-condensed',
+			'extra-condensed'	=> 'extra-condensed',
+			'condensed'			=> 'condensed',
+			'semi-condensed'	=> 'semi-condensed',
+			'normal'			=> 'normal',
+			'semi-expanded'		=> 'semi-expanded',
+			'expanded'			=> 'expanded',
+			'extra-expanded'	=> 'extra-expanded',
+			'ultra-expanded'	=> 'ultra-expanded',
+			'initial'			=> 'initial',
+			'inherit'			=> 'inherit'
 		);
 		$this->text_align = array(
 			'inherit'	=> 'inherit',
@@ -143,20 +143,20 @@ class acf_field_Typography extends acf_field {
 			'initial'	=> 'initial'
 		);
 		$this->text_decoration = array(
-			'none' 		=> 'none',
-			'underline' 	=> 'underline',
-			'overline' 	=> 'overline',
-			'line-through' 	=> 'line-through',
-			'initial' 	=> 'initial',
-			'inherit' 	=> 'inherit'
+			'none'			=> 'none',
+			'underline'		=> 'underline',
+			'overline'		=> 'overline',
+			'line-through'	=> 'line-through',
+			'initial'		=> 'initial',
+			'inherit'		=> 'inherit'
 		);
 		$this->text_transform = array(
-			'none' 		=> 'none',
-			'capitalize' 	=> 'capitalize',
-			'uppercase' 	=> 'uppercase',
-			'lowercase' 	=> 'lowercase',
-			'initial' 	=> 'initial',
-			'inherit' 	=> 'inherit'
+			'none'			=> 'none',
+			'capitalize'	=> 'capitalize',
+			'uppercase'		=> 'uppercase',
+			'lowercase'		=> 'lowercase',
+			'initial'		=> 'initial',
+			'inherit'		=> 'inherit'
 		);
 		
 		
@@ -178,8 +178,8 @@ class acf_field_Typography extends acf_field {
 		
 		
 		// do not delete!
-    	parent::__construct();
-    	
+		parent::__construct();
+		
 	}
 	
 	
@@ -209,150 +209,150 @@ class acf_field_Typography extends acf_field {
 		*/
 		
 		acf_render_field_setting( $field, array(
-			'label'		=> __('Display Properties','acf-typography'),
+			'label'			=> __('Display Properties','acf-typography'),
 			'instructions'	=> __('Select fields to display on edit page','acf-typography'),
-			'type'		=> 'checkbox',
-			'name'		=> 'display_properties',
-			'choices'       =>  array(
-				'font_size'         =>  __("Font Size",'acf-typography'),
-				'font_family'       =>  __("Font Family",'acf-typography'),
-				'font_weight'       =>  __("Font Weight",'acf-typography'),
-				'font_style'        =>  __("Font Style",'acf-typography'),
-                                'font_variant'      =>  __("Font Variant",'acf-typography'),
-                                'font_stretch'      =>  __("Font Stretch",'acf-typography'),
-				'line_height'       =>  __("Line Height",'acf-typography'),
-				'letter_spacing'    =>  __("Letter Spacing",'acf-typography'),
-				'text_align'        =>  __("Text Align",'acf-typography'),
-				'text_color'        =>  __("Text Color",'acf-typography'),
-				'text_decoration'   =>  __("Text Decoration",'acf-typography'),
-				'text_transform'    =>  __("Text Transform",'acf-typography'),
+			'type'			=> 'checkbox',
+			'name'			=> 'display_properties',
+			'choices'		=>  array(
+				'font_size'			=>  __("Font Size",'acf-typography'),
+				'font_family'		=>  __("Font Family",'acf-typography'),
+				'font_weight'		=>  __("Font Weight",'acf-typography'),
+				'font_style'		=>  __("Font Style",'acf-typography'),
+				'font_variant'		=>  __("Font Variant",'acf-typography'),
+				'font_stretch'		=>  __("Font Stretch",'acf-typography'),
+				'line_height'		=>  __("Line Height",'acf-typography'),
+				'letter_spacing'	=>  __("Letter Spacing",'acf-typography'),
+				'text_align'		=>  __("Text Align",'acf-typography'),
+				'text_color'		=>  __("Text Color",'acf-typography'),
+				'text_decoration'	=>  __("Text Decoration",'acf-typography'),
+				'text_transform'	=>  __("Text Transform",'acf-typography'),
 			),
-			'layout'        =>  'horizontal',
+			'layout'		=>  'horizontal',
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'		=> __('Required Properties','acf-typography'),
+			'label'			=> __('Required Properties','acf-typography'),
 			'instructions'	=> __('Select fields which are required on edit page','acf-typography'),
-			'type'		=> 'checkbox',
-			'name'		=> 'required_properties',
-			'choices'       =>  array(
-				'font_size'         =>  __("Font Size",'acf-typography'),
-				'font_family'       =>  __("Font Family",'acf-typography'),
-				'font_weight'       =>  __("Font Weight",'acf-typography'),
-				'font_style'        =>  __("Font Style",'acf-typography'),
-                                'font_variant'      =>  __("Font Variant",'acf-typography'),
-                                'font_stretch'      =>  __("Font Stretch",'acf-typography'),
-				'line_height'       =>  __("Line Height",'acf-typography'),
-				'letter_spacing'    =>  __("Letter Spacing",'acf-typography'),
-				'text_align'        =>  __("Text Align",'acf-typography'),
-				'text_color'        =>  __("Text Color",'acf-typography'),
-				'text_decoration'   =>  __("Text Decoration",'acf-typography'),
-				'text_transform'    =>  __("Text Transform",'acf-typography'),
+			'type'			=> 'checkbox',
+			'name'			=> 'required_properties',
+			'choices'		=> array(
+				'font_size'			=>  __("Font Size",'acf-typography'),
+				'font_family'		=>  __("Font Family",'acf-typography'),
+				'font_weight'		=>  __("Font Weight",'acf-typography'),
+				'font_style'		=>  __("Font Style",'acf-typography'),
+				'font_variant'		=>  __("Font Variant",'acf-typography'),
+				'font_stretch'		=>  __("Font Stretch",'acf-typography'),
+				'line_height'		=>  __("Line Height",'acf-typography'),
+				'letter_spacing'	=>  __("Letter Spacing",'acf-typography'),
+				'text_align'		=>  __("Text Align",'acf-typography'),
+				'text_color'		=>  __("Text Color",'acf-typography'),
+				'text_decoration'	=>  __("Text Decoration",'acf-typography'),
+				'text_transform'	=>  __("Text Transform",'acf-typography'),
 			),
-			'layout'        =>  'horizontal',
+			'layout'		=> 'horizontal',
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'		=> __('Font Size','acf-typography'),
+			'label'			=> __('Font Size','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'		=> 'number',
-			'name'		=> 'font_size',
-			'append'        => 'px'
+			'type'			=> 'number',
+			'name'			=> 'font_size',
+			'append'		=> 'px'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'		=> __('Font Family','acf-typography'),
+			'label'			=> __('Font Family','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'		=> 'select',
-			'name'		=> 'font_family',
-			'choices'       => $this->font_family,
-			'layout'        => 'horizontal'
+			'type'			=> 'select',
+			'name'			=> 'font_family',
+			'choices'		=> $this->font_family,
+			'layout'		=> 'horizontal'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'		=> __('Font Weight','acf-typography'),
+			'label'			=> __('Font Weight','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'		=> 'select',
-			'name'		=> 'font_weight',
-			'choices'       => $this->font_weight,
-			'layout'        => 'horizontal'
+			'type'			=> 'select',
+			'name'			=> 'font_weight',
+			'choices'		=> $this->font_weight,
+			'layout'		=> 'horizontal'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'		=> __('Font Style','acf-typography'),
+			'label'			=> __('Font Style','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'		=> 'select',
-			'name'		=> 'font_style',
-			'choices'       => $this->font_style,
-			'layout'        => 'horizontal'
+			'type'			=> 'select',
+			'name'			=> 'font_style',
+			'choices'		=> $this->font_style,
+			'layout'		=> 'horizontal'
 		));
-        
-                acf_render_field_setting( $field, array(
-			'label'		=> __('Font Variant','acf-typography'),
+
+		acf_render_field_setting( $field, array(
+			'label'			=> __('Font Variant','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'		=> 'select',
-			'name'		=> 'font_variant',
-			'choices'       => $this->font_variant,
-			'layout'        => 'horizontal'
+			'type'			=> 'select',
+			'name'			=> 'font_variant',
+			'choices'		=> $this->font_variant,
+			'layout'		=> 'horizontal'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'		=> __('Font Stretch','acf-typography'),
+			'label'			=> __('Font Stretch','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'		=> 'select',
-			'name'		=> 'font_stretch',
-			'choices'       => $this->font_stretch,
-			'layout'        => 'horizontal'
+			'type'			=> 'select',
+			'name'			=> 'font_stretch',
+			'choices'		=> $this->font_stretch,
+			'layout'		=> 'horizontal'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'		=> __('Line Height','acf-typography'),
+			'label'			=> __('Line Height','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'		=> 'number',
-			'name'		=> 'line_height',
-			'append'        => 'px'
+			'type'			=> 'number',
+			'name'			=> 'line_height',
+			'append'		=> 'px'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'		=> __('Letter Spacing','acf-typography'),
+			'label'			=> __('Letter Spacing','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'		=> 'number',
-			'name'		=> 'letter_spacing',
-			'append'        => 'px'
+			'type'			=> 'number',
+			'name'			=> 'letter_spacing',
+			'append'		=> 'px'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'		=> __('Text Align','acf-typography'),
+			'label'			=> __('Text Align','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'		=> 'select',
-			'name'		=> 'text_align',
-			'choices'       => $this->text_align,
-			'layout'        => 'horizontal'
+			'type'			=> 'select',
+			'name'			=> 'text_align',
+			'choices'		=> $this->text_align,
+			'layout'		=> 'horizontal'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'		=> __('Text Color','acf-typography'),
+			'label'			=> __('Text Color','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-                        'type'		=> 'color_picker', // changed from 'text' to 'color_picker' for v5 & v6 compatibility 
-			'name'		=> 'text_color',
+			'type'			=> 'color_picker', // changed from 'text' to 'color_picker' for v5 & v6 compatibility 
+			'name'			=> 'text_color',
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'		=> __('Text Decoration','acf-typography'),
+			'label'			=> __('Text Decoration','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'		=> 'select',
-			'name'		=> 'text_decoration',
-			'choices'       => $this->text_decoration,
-			'layout'        => 'horizontal'
+			'type'			=> 'select',
+			'name'			=> 'text_decoration',
+			'choices'		=> $this->text_decoration,
+			'layout'		=> 'horizontal'
 		));
 		
 		acf_render_field_setting( $field, array(
-			'label'		=> __('Text Transform','acf-typography'),
+			'label'			=> __('Text Transform','acf-typography'),
 			'instructions'	=> __('Default','acf-typography'),
-			'type'		=> 'select',
-			'name'		=> 'text_transform',
-			'choices'       => $this->text_transform,
-			'layout'        => 'horizontal'
+			'type'			=> 'select',
+			'name'			=> 'text_transform',
+			'choices'		=> $this->text_transform,
+			'layout'		=> 'horizontal'
 		));
 
 	}
@@ -384,101 +384,89 @@ class acf_field_Typography extends acf_field {
 		// create Field HTML
 		
 		if( !empty( $field['display_properties'] ) && sizeof($field['display_properties']) > 0){
-		    
-		    foreach( $field['display_properties'] as $f ){
-		        
-		        $numbers = $selects = array();
-		        
-		        $data_required = '';
-		        
-		        $required = '';
-		        if( is_array($field['required_properties']) && in_array($f, $field['required_properties']) ){
-                                $required = 'required';
-                                $data_required = 'data-required="1"';
-                        }
+
+			foreach( $field['display_properties'] as $f ){
 				
-                        if( $f == 'font_size' || $f == 'line_height' || $f == 'letter_spacing' ){
-                                $numbers[] = $f;
-                        }else if( $f == 'font_family' || $f == 'font_weight' || $f == 'font_style' || $f == 'font_variant' || $f == 'font_stretch' || $f == 'text_align' || $f == 'text_decoration' || $f == 'text_transform' ){
-                                $selects[] = $f;
-                        }
+				$numbers = $selects = array();
+				
+				$data_required = '';
+				
+				$required = '';
+				if( is_array($field['required_properties']) && in_array($f, $field['required_properties']) ){
+								$required = 'required';
+								$data_required = 'data-required="1"';
+						}
+				
+						if( $f == 'font_size' || $f == 'line_height' || $f == 'letter_spacing' ){
+								$numbers[] = $f;
+						}else if( $f == 'font_family' || $f == 'font_weight' || $f == 'font_style' || $f == 'font_variant' || $f == 'font_stretch' || $f == 'text_align' || $f == 'text_decoration' || $f == 'text_transform' ){
+								$selects[] = $f;
+						}
 
-                        if( in_array($f, $numbers) ){
-                    ?>
-
-
-                    <div class="acf-field acf-field-number acf-field-<?php echo $f; ?>" data-name="<?php echo $f; ?>" data-type="number" data-key="<?php echo $key; ?>" <?php echo $data_required; ?>>
-                    	<div class="acf-label">
-                    		<label for="acf-field-<?php echo $f; ?>">
-                    		    <?php echo __(ucwords(str_replace('_', ' ', $f)), 'acf-typography'); ?>
-                    		    <?php if(!empty($required)){ ?>
-                                            <span class="acf-required">*</span></label>
-                                    <?php } ?>
-                    	</div>                            
-                    	<div class="acf-input">
-                    		<div class="acf-input-append">px</div>
-                    		<div class="acf-input-wrap">
-                    		    <input type="number" id="<?php echo 'acf-field-'.$f; ?>" class="acf-is-appended" min="" max="" step="any" name="<?php echo esc_attr($field['name'].'['.$f.']') ?>" value="<?php echo esc_attr(( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] )) ?>">
-                    		</div>
-                    	</div>
-                    </div>
-
-
-                    <?php
-                        }else  if( in_array($f, $selects) ){
-                    ?>
-
-
-                    <div class="acf-field acf-field-select acf-field-<?php echo $f; ?>" data-name="<?php echo $f; ?>" data-type="select" data-key="<?php echo $key; ?>" <?php echo $data_required; ?>>
-                    	<div class="acf-label">
-                    		<label for="acf-field-<?php echo $f; ?>">
-                    		    <?php echo __(ucwords(str_replace('_', ' ', $f)), 'acf-typography'); ?>
-                    		    <?php if(!empty($required)){ ?>
-                                            <span class="acf-required">*</span></label>
-                                    <?php } ?>
-                    	</div>
-                    	<div class="acf-input">
-                    		<select id="acf-<?php echo $f; ?>" class="" name="<?php echo $field['name'].'['.$f.']'; ?>" data-ui="0" data-ajax="0" data-multiple="0" data-placeholder="Select" data-allow_null="0">
-                    		    <?php 
-                                        $options = '';
-                                        foreach($this->$f as $opt){
-                                                if( !empty($field['value'][$f]) )
-                                                        $options .= '<option val="'.$opt.'" '. ($field['value'][$f] == $opt? 'selected': '') .'>'.$opt.'</option>';
-                                                else
-                                                        $options .= '<option val="'.$opt.'" '. ($field[$f] == $opt? 'selected': '') .'>'.$opt.'</option>';
-                                        }
-                                        echo $options;
-                                    ?>
-                    		</select>
-                    	</div>
-                    </div>
-
-
-                    <?php
-                        }else{
-                    ?>
-
-
-                    <div class="acf-field acf-field-color-picker acf-field-<?php echo $f; ?>" data-name="<?php echo $f; ?>" data-type="color_picker" data-key="<?php echo $key; ?>" <?php echo $data_required; ?>>
-                    	<div class="acf-label">
-                    		<label for="acf-field-<?php echo $f; ?>">
-                    		    <?php echo __(ucwords(str_replace('_', ' ', $f)), 'acf-typography'); ?>
-                    		    <?php if(!empty($required)){ ?>
-                                            <span class="acf-required">*</span></label>
-                                    <?php } ?>
-                    	</div>
-                    	<div class="acf-input">
-                    		<div class="acf-color_picker">
-                                        <input type="hidden" name="<?php echo esc_attr($field['name'].'['.$f.']') ?>" value="<?php echo esc_attr(( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] )) ?>">
-                                        <input type="text" id="<?php echo 'acf-field-'.$f; ?>" name="<?php echo esc_attr($field['name'].'['.$f.']') ?>" value="<?php echo esc_attr(( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] )) ?>">
-                                </div>
-                    	</div>
-                    </div>
-
-
-                    <?php
-                        }
-		    }
+						if( in_array($f, $numbers) ){
+					?>
+					<div class="acf-field acf-field-number acf-field-<?php echo $f; ?>" data-name="<?php echo $f; ?>" data-type="number" data-key="<?php echo $key; ?>" <?php echo $data_required; ?>>
+						<div class="acf-label">
+							<label for="acf-field-<?php echo $f; ?>">
+								<?php echo __(ucwords(str_replace('_', ' ', $f)), 'acf-typography'); ?>
+								<?php if(!empty($required)){ ?>
+											<span class="acf-required">*</span></label>
+									<?php } ?>
+						</div>
+						<div class="acf-input">
+							<div class="acf-input-append">px</div>
+							<div class="acf-input-wrap">
+								<input type="number" id="<?php echo 'acf-field-'.$f; ?>" class="acf-is-appended" min="" max="" step="any" name="<?php echo esc_attr($field['name'].'['.$f.']') ?>" value="<?php echo esc_attr(( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] )) ?>">
+							</div>
+						</div>
+					</div>
+					<?php
+						}else  if( in_array($f, $selects) ){
+					?>
+					<div class="acf-field acf-field-select acf-field-<?php echo $f; ?>" data-name="<?php echo $f; ?>" data-type="select" data-key="<?php echo $key; ?>" <?php echo $data_required; ?>>
+						<div class="acf-label">
+							<label for="acf-field-<?php echo $f; ?>">
+								<?php echo __(ucwords(str_replace('_', ' ', $f)), 'acf-typography'); ?>
+								<?php if(!empty($required)){ ?>
+											<span class="acf-required">*</span></label>
+									<?php } ?>
+						</div>
+						<div class="acf-input">
+							<select id="acf-<?php echo $f; ?>" class="" name="<?php echo $field['name'].'['.$f.']'; ?>" data-ui="0" data-ajax="0" data-multiple="0" data-placeholder="Select" data-allow_null="0">
+								<?php 
+										$options = '';
+										foreach($this->$f as $opt){
+												if( !empty($field['value'][$f]) )
+														$options .= '<option val="'.$opt.'" '. ($field['value'][$f] == $opt? 'selected': '') .'>'.$opt.'</option>';
+												else
+														$options .= '<option val="'.$opt.'" '. ($field[$f] == $opt? 'selected': '') .'>'.$opt.'</option>';
+										}
+										echo $options;
+									?>
+							</select>
+						</div>
+					</div>
+					<?php
+						}else{
+					?>
+					<div class="acf-field acf-field-color-picker acf-field-<?php echo $f; ?>" data-name="<?php echo $f; ?>" data-type="color_picker" data-key="<?php echo $key; ?>" <?php echo $data_required; ?>>
+						<div class="acf-label">
+							<label for="acf-field-<?php echo $f; ?>">
+								<?php echo __(ucwords(str_replace('_', ' ', $f)), 'acf-typography'); ?>
+								<?php if(!empty($required)){ ?>
+											<span class="acf-required">*</span></label>
+									<?php } ?>
+						</div>
+						<div class="acf-input">
+							<div class="acf-color_picker">
+										<input type="hidden" name="<?php echo esc_attr($field['name'].'['.$f.']') ?>" value="<?php echo esc_attr(( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] )) ?>">
+										<input type="text" id="<?php echo 'acf-field-'.$f; ?>" name="<?php echo esc_attr($field['name'].'['.$f.']') ?>" value="<?php echo esc_attr(( !empty($field['value'][$f]) ? $field['value'][$f] : $field[$f] )) ?>">
+								</div>
+						</div>
+					</div>
+					<?php
+						}
+			}
 		}
 	}
 	
@@ -546,33 +534,33 @@ class acf_field_Typography extends acf_field {
 	
 	
 	/*
-   	*  input_form_data()
-   	*
-   	*  This function is called once on the 'input' page between the head and footer
-   	*  There are 2 situations where ACF did not load during the 'acf/input_admin_enqueue_scripts' and 
-   	*  'acf/input_admin_head' actions because ACF did not know it was going to be used. These situations are
-   	*  seen on comments / user edit forms on the front end. This function will always be called, and includes
-   	*  $args that related to the current screen such as $args['post_id']
-   	*
-   	*  @type	function
-   	*  @date	6/03/2014
-   	*  @since	5.0.0
-   	*
-   	*  @param	$args (array)
-   	*  @return	n/a
-   	*/
-   	
-   	/*
-   	
-   	function input_form_data( $args ) {
-	   	
+	*  input_form_data()
+	*
+	*  This function is called once on the 'input' page between the head and footer
+	*  There are 2 situations where ACF did not load during the 'acf/input_admin_enqueue_scripts' and 
+	*  'acf/input_admin_head' actions because ACF did not know it was going to be used. These situations are
+	*  seen on comments / user edit forms on the front end. This function will always be called, and includes
+	*  $args that related to the current screen such as $args['post_id']
+	*
+	*  @type	function
+	*  @date	6/03/2014
+	*  @since	5.0.0
+	*
+	*  @param	$args (array)
+	*  @return	n/a
+	*/
+
+	/*
+
+	function input_form_data( $args ) {
 		
-	
-   	}
-   	
-   	*/
-	
-	
+		
+
+	}
+
+	*/
+
+
 	/*
 	*  input_admin_footer()
 	*
@@ -741,13 +729,13 @@ class acf_field_Typography extends acf_field {
 		
 		if ($field['required_properties']) {
 			
-		    foreach( $field['required_properties'] as $rf){
-		    	
-		    	if( in_array($rf, $field['display_properties']) && empty($value[$rf] ) ){
-		    		acf_validate_value( $value[ $rf ], ' ', $field['prefix'].'['.$field['key'].']['.$rf.']' );
-		    	}
-		    	
-		    }
+			foreach( $field['required_properties'] as $rf){
+				
+				if( in_array($rf, $field['display_properties']) && empty($value[$rf] ) ){
+					acf_validate_value( $value[ $rf ], ' ', $field['prefix'].'['.$field['key'].']['.$rf.']' );
+				}
+				
+			}
 			
 		}
 		

--- a/fields/acf-Typography-v6.php
+++ b/fields/acf-Typography-v6.php
@@ -1,0 +1,22 @@
+<?php
+
+// exit if accessed directly
+if( ! defined( 'ABSPATH' ) ) exit;
+
+/*
+ * 
+ * This file exists as a placeholder for the call for 
+ * include_field_types from acf-typography.php to register
+ * the fields for this plugin, if/when ACF will utilize it.
+ * 
+ * ACF v5 fields currently work fine for v6 (with only two bugs 
+ * related to number fields and color_picker), so until there's 
+ * actually a reason to do something different for v6, we just
+ * use the existing v5 fields file and keep this file here to prevent
+ * surprise plugin errors if/when ACF makes changes in the future.
+ * 
+ * Both Bugs are UI-related and have been reported to ACF for patching.
+ * 
+ */
+
+require_once plugin_dir_path( __FILE__ ) . 'acf-Typography-v5.php';

--- a/includes/admin_settings.php
+++ b/includes/admin_settings.php
@@ -12,7 +12,14 @@ add_action( 'admin_init', 'acft_settings_init' );
 
 function acft_add_admin_menu(){ 
 
-	add_submenu_page( 'options-general.php', 'ACF Typography Settings', 'ACF Typography Settings', 'manage_options', 'acf-typography-field', 'acft_options_page' );
+	add_submenu_page( 
+                'options-general.php', 
+                __('ACF Typography', 'acf-typography' ), // "Settings" removed from menu name to keep it on 1-line
+                __('ACF Typography', 'acf-typography' ),  
+                'manage_options', 
+                'acf-typography-field', 
+                'acft_options_page' 
+        );
 
 }
 
@@ -22,20 +29,158 @@ function acft_settings_init(){
 
 	add_settings_section(
 		'acft_acf-typography-field_section', 
-		__( '', 'acf' ), 
+		'', // as per WP Docs, empty strings should not be translated 
 		'acft_settings_section_callback', 
 		'acf-typography-field'
 	);
 
 	add_settings_field( 
 		'acft_text_field_0', 
-		__( 'Google Fonts Key', 'acf' ), 
+		__( 'Google Fonts Key', 'acf-typography' ), 
 		'acft_google_key_field', 
 		'acf-typography-field', 
 		'acft_acf-typography-field_section' 
 	);
 
 
+}
+
+
+/**
+ *  Check if ACF installed & active
+ * 
+ *  acft_acf_active_check()
+ * 
+ *  @return     (str)
+ *                  If error: HTML code for error & help messages
+ *                  If no error: n/a
+ * 
+ *  @since      3.2.4
+ */
+function acft_acf_active_check() {
+    
+        // error message if ACF not installed/active
+        if (!class_exists('ACF')) { ?>
+
+                <div id="setting-error-settings_acf_required" class="notice notice-error settings-error is-dismissible">
+                    
+                    
+                        <h3><strong>
+                                <?php _e("Advanced Custom Fields plugin is required!", 'acf-typography') ?>
+                        </strong></h3>
+                    
+                    
+                        <p><?php echo sprintf( 
+                                /* translators: 1: ACF WP plugin directory url, 2: 'target="_blank"' HTML code tag, 3: 'title=' HTML code tag */    
+                                __('This plugin does nothing by itself, and requires <a href="%1$s" %2$s %3$s"Advanced Custom Fields">Advanced Custom Fields</a> (ACF) to be installed and activated. This ACF Typography Field plugin will work with both free or paid PRO versions of ACF, versions 4, 5 & 6!', 'acf-typography'),
+                                esc_url('https://wordpress.org/plugins/advanced-custom-fields/'),
+                                'target="_blank"',
+                                'title=',
+                        ); ?></p>
+                        
+                        
+                        <button type="button" class="notice-dismiss"><span class="screen-reader-text">
+                                <?php 
+                                    /* translators: Used for screen-reader-text to dismiss admin panel error messages. */ 
+                                    _e("Dismiss this notice.", 'acf-typography'); 
+                                ?>
+                        </span></button>
+                        
+                        
+                </div>
+
+        <?php }
+        
+}
+
+
+/**
+ *  Check Google API Key for validity & good response
+ * 
+ *  acft_google_api_key_check( $google_key )
+ * 
+ *  @param      (str) $google_key
+ *                  The supplied API Key to test
+ *  @param      (str) $g_api_url 
+ *                  URL to the Google Developer API
+ * 
+ *  @return     (str)
+ *                  If error: HTML code for error & help messages
+ *                  If no error: n/a
+ * 
+ *  @since      3.2.4
+ */
+function acft_google_api_key_check( $google_key,  $g_api_url  ) {
+            
+        // API Key URL to test
+        $api_key_url = esc_url( 'https://www.googleapis.com/webfonts/v1/webfonts?key=' . $google_key );
+
+        // it out and suppress errors for now
+        $url_test = @file_get_contents( $api_key_url );
+
+        // if we got back a bad response, display a message
+        if ( $url_test === false ) { ?>
+
+            <div id="setting-error-settings_bad_api_response" class="notice notice-error settings-error is-dismissible">
+
+                <h3><strong>
+                    <?php _e("Bad Response from Google API.", 'acf-typography') ?>
+                </strong></h3>
+
+
+                <?php
+                // display HTTP Header Response Error Code if present
+                if (isset($http_response_header[0])) {
+                        echo 
+                        /* translators: Used for displaying HTTP Header Response Error Messages */ 
+                        __("HTTP Response Error: ", 'acf-typography').'<strong>'.$http_response_header[0].'</strong><br>'; 
+                } 
+
+
+                // display Google API Error Message if present
+                $context = stream_context_create(['http' => ['ignore_errors' => true]]);
+                $url_response = json_decode(file_get_contents($api_key_url, false, $context), true);
+                if (isset($url_response['error']['message'])) { 
+                        echo 
+                        /* translators: Used for displaying Google API Error Messages */ 
+                        __("Google Error: ", 'acf-typography').'<strong>'.$url_response['error']['message'].'</strong><br>'; 
+                } ?>
+
+
+                <p><ul><?php 
+                        // error help messages
+                        echo '<li>'.__("Check your API Key to make sure it is correct.", "acf-typography").'</li>';
+                        echo '<li>'.__("Check your settings in the Developer API to ensure that you have allowed this API key to be used without restrictions for this domain.", "acf-typography").'</li>';
+                        echo '<li>'.__("Check the API Key Response link below to ensure you're actually getting back results.", "acf-typography").'</li>';
+                ?></ul></p>
+
+
+                <p><?php 
+                        // error help links
+                        echo
+                        /* translators: Used for Google Developer API admin panel error message links. */
+                        __("Developer API: ", 'acf-typography').'<a href="'.$g_api_url.'" target="_blank">'.$g_api_url.'</a>'; ?>
+                        <br>
+                        <?php 
+                        echo 
+                        /* translators: Used for Google Developer API admin panel error message links. */
+                        __("API Key Response: ", 'acf-typography').'<a href="'.$api_key_url.'" target="_blank">'.$api_key_url.'</a>'; 
+                ?></p>
+
+
+                <button type="button" class="notice-dismiss"><span class="screen-reader-text">
+                    <?php 
+                        /* translators: Used for screen-reader-text to dismiss admin panel error messages. */ 
+                        _e("Dismiss this notice.", 'acf-typography'); 
+                    ?>
+
+                </span></button>
+                
+
+            </div>
+
+        <?php } // end if bad response
+            
 }
 
 
@@ -47,8 +192,21 @@ function acft_google_key_field(){
 		$google_key = $acft_options['google_key']
 	?>
 	<input type='text' name='acft_settings[google_key]' value='<?php echo $google_key; ?>'>
+	        
+        <?php $g_api_url = esc_url( 'https://developers.google.com/fonts/docs/developer_api' ); ?>
+        
+        <p><?php echo sprintf( 
+            /* translators: 1: google fonts api url, 2: target="_blank" to open in new tab */    
+            __( 'You can get an API key <a href="%1$s" %2$s title="Google Fonts API">HERE</a>.', 'acf-typography' ), 
+            $g_api_url,
+            'target="_blank"'
+        ); ?></p>
 	<?php
-
+        
+        // is there a Google API Key?
+        if ( !empty($google_key) )
+            echo acft_google_api_key_check( $google_key, $g_api_url );
+ 
 }
 
 
@@ -60,9 +218,13 @@ function acft_options_page(){
 	?>
 	<form action='options.php' method='post'>
 
-		<h2>ACF Typography Settings</h2>
+		<h2><?php _e("ACF Typography Settings", 'acf-typography'); ?></h2>
 
 		<?php
+                
+                // display ACF must be active message if ACF not installed/active
+                echo acft_acf_active_check();
+                
 		settings_fields( 'acf-typography-field' );
 		do_settings_sections( 'acf-typography-field' );
 		submit_button();

--- a/includes/admin_settings.php
+++ b/includes/admin_settings.php
@@ -12,7 +12,7 @@ add_action( 'admin_init', 'acft_settings_init' );
 
 function acft_add_admin_menu(){ 
 
-	add_submenu_page( 
+        add_submenu_page( 
                 'options-general.php', 
                 __('ACF Typography', 'acf-typography' ), // "Settings" removed from menu name to keep it on 1-line
                 __('ACF Typography', 'acf-typography' ),  
@@ -61,15 +61,10 @@ function acft_acf_active_check() {
     
         // error message if ACF not installed/active
         if (!class_exists('ACF')) { ?>
-
                 <div id="setting-error-settings_acf_required" class="notice notice-error settings-error is-dismissible">
-                    
-                    
                         <h3><strong>
                                 <?php _e("Advanced Custom Fields plugin is required!", 'acf-typography') ?>
                         </strong></h3>
-                    
-                    
                         <p><?php echo sprintf( 
                                 /* translators: 1: ACF WP plugin directory url, 2: 'target="_blank"' HTML code tag, 3: 'title=' HTML code tag */    
                                 __('This plugin does nothing by itself, and requires <a href="%1$s" %2$s %3$s"Advanced Custom Fields">Advanced Custom Fields</a> (ACF) to be installed and activated. This ACF Typography Field plugin will work with both free or paid PRO versions of ACF, versions 4, 5 & 6!', 'acf-typography'),
@@ -77,18 +72,13 @@ function acft_acf_active_check() {
                                 'target="_blank"',
                                 'title=',
                         ); ?></p>
-                        
-                        
                         <button type="button" class="notice-dismiss"><span class="screen-reader-text">
                                 <?php 
-                                    /* translators: Used for screen-reader-text to dismiss admin panel error messages. */ 
-                                    _e("Dismiss this notice.", 'acf-typography'); 
+                                        /* translators: Used for screen-reader-text to dismiss admin panel error messages. */ 
+                                        _e("Dismiss this notice.", 'acf-typography'); 
                                 ?>
                         </span></button>
-                        
-                        
                 </div>
-
         <?php }
         
 }
@@ -120,14 +110,10 @@ function acft_google_api_key_check( $google_key,  $g_api_url  ) {
 
         // if we got back a bad response, display a message
         if ( $url_test === false ) { ?>
-
             <div id="setting-error-settings_bad_api_response" class="notice notice-error settings-error is-dismissible">
-
-                <h3><strong>
+                <h3>
                     <?php _e("Bad Response from Google API.", 'acf-typography') ?>
-                </strong></h3>
-
-
+                </h3>
                 <?php
                 // display HTTP Header Response Error Code if present
                 if (isset($http_response_header[0])) {
@@ -135,8 +121,6 @@ function acft_google_api_key_check( $google_key,  $g_api_url  ) {
                         /* translators: Used for displaying HTTP Header Response Error Messages */ 
                         __("HTTP Response Error: ", 'acf-typography').'<strong>'.$http_response_header[0].'</strong><br>'; 
                 } 
-
-
                 // display Google API Error Message if present
                 $context = stream_context_create(['http' => ['ignore_errors' => true]]);
                 $url_response = json_decode(file_get_contents($api_key_url, false, $context), true);
@@ -145,16 +129,12 @@ function acft_google_api_key_check( $google_key,  $g_api_url  ) {
                         /* translators: Used for displaying Google API Error Messages */ 
                         __("Google Error: ", 'acf-typography').'<strong>'.$url_response['error']['message'].'</strong><br>'; 
                 } ?>
-
-
                 <p><ul><?php 
                         // error help messages
                         echo '<li>'.__("Check your API Key to make sure it is correct.", "acf-typography").'</li>';
                         echo '<li>'.__("Check your settings in the Developer API to ensure that you have allowed this API key to be used without restrictions for this domain.", "acf-typography").'</li>';
                         echo '<li>'.__("Check the API Key Response link below to ensure you're actually getting back results.", "acf-typography").'</li>';
                 ?></ul></p>
-
-
                 <p><?php 
                         // error help links
                         echo
@@ -166,8 +146,6 @@ function acft_google_api_key_check( $google_key,  $g_api_url  ) {
                         /* translators: Used for Google Developer API admin panel error message links. */
                         __("API Key Response: ", 'acf-typography').'<a href="'.$api_key_url.'" target="_blank">'.$api_key_url.'</a>'; 
                 ?></p>
-
-
                 <button type="button" class="notice-dismiss"><span class="screen-reader-text">
                     <?php 
                         /* translators: Used for screen-reader-text to dismiss admin panel error messages. */ 
@@ -175,10 +153,7 @@ function acft_google_api_key_check( $google_key,  $g_api_url  ) {
                     ?>
 
                 </span></button>
-                
-
             </div>
-
         <?php } // end if bad response
             
 }
@@ -191,10 +166,8 @@ function acft_google_key_field(){
 	if( $acft_options && $acft_options['google_key'] )
 		$google_key = $acft_options['google_key']
 	?>
-	<input type='text' name='acft_settings[google_key]' value='<?php echo $google_key; ?>'>
-	        
+	<input type='text' name='acft_settings[google_key]' value='<?php echo $google_key; ?>'>    
         <?php $g_api_url = esc_url( 'https://developers.google.com/fonts/docs/developer_api' ); ?>
-        
         <p><?php echo sprintf( 
             /* translators: 1: google fonts api url, 2: target="_blank" to open in new tab */    
             __( 'You can get an API key <a href="%1$s" %2$s title="Google Fonts API">HERE</a>.', 'acf-typography' ), 
@@ -202,10 +175,8 @@ function acft_google_key_field(){
             'target="_blank"'
         ); ?></p>
 	<?php
-        
         // is there a Google API Key?
-        if ( !empty($google_key) )
-            echo acft_google_api_key_check( $google_key, $g_api_url );
+        if ( !empty($google_key) ) echo acft_google_api_key_check( $google_key, $g_api_url );
  
 }
 
@@ -217,19 +188,15 @@ function acft_options_page(){
 
 	?>
 	<form action='options.php' method='post'>
-
 		<h2><?php _e("ACF Typography Settings", 'acf-typography'); ?></h2>
-
 		<?php
-                
-                // display ACF must be active message if ACF not installed/active
-                echo acft_acf_active_check();
-                
-		settings_fields( 'acf-typography-field' );
-		do_settings_sections( 'acf-typography-field' );
-		submit_button();
-		?>
+                        // display ACF must be active message if ACF not installed/active
+                        echo acft_acf_active_check();
 
+                        settings_fields( 'acf-typography-field' );
+                        do_settings_sections( 'acf-typography-field' );
+                        submit_button();
+		?>
 	</form>
 	<?php
 

--- a/includes/admin_settings.php
+++ b/includes/admin_settings.php
@@ -70,7 +70,7 @@ function acft_acf_active_check() {
                                 __('This plugin does nothing by itself, and requires <a href="%1$s" %2$s %3$s"Advanced Custom Fields">Advanced Custom Fields</a> (ACF) to be installed and activated. This ACF Typography Field plugin will work with both free or paid PRO versions of ACF, versions 4, 5 & 6!', 'acf-typography'),
                                 esc_url('https://wordpress.org/plugins/advanced-custom-fields/'),
                                 'target="_blank"',
-                                'title=',
+                                'title='
                         ); ?></p>
                         <button type="button" class="notice-dismiss"><span class="screen-reader-text">
                                 <?php 

--- a/includes/api-template.php
+++ b/includes/api-template.php
@@ -11,7 +11,7 @@ function get_typography_field( $selector, $property, $post_id = false, $format_v
 	$post_id = acf_get_valid_post_id( $post_id );
 	
 	// get field
-    $field = acf_maybe_get_field( $selector, $post_id );
+        $field = acf_maybe_get_field( $selector, $post_id );
 	
 	// create dummy field
 	if( !$field ) {	
@@ -26,19 +26,19 @@ function get_typography_field( $selector, $property, $post_id = false, $format_v
 	}
 	
 	// get value for field
-    $value = acf_get_value( $post_id, $field );
+        $value = acf_get_value( $post_id, $field );
 	
 	// format value
 	if( $format_value ) {	
 		// get value for field
 		$value = acf_format_value( $value, $post_id, $field );
-    }
+        }
     
-    // get property
-    if( is_array($value) && array_key_exists( $property, $value ) )
-        $property_value = esc_attr($value[ $property ]);
-    else
-        $property_value = '';
+        // get property
+        if( is_array( $value ) && array_key_exists( $property, $value ) )
+            $property_value = esc_attr( $value[ $property ] );
+        else
+            $property_value = '';
     
 	return $property_value;
  
@@ -51,9 +51,9 @@ function get_typography_field( $selector, $property, $post_id = false, $format_v
  */
 function the_typography_field( $selector, $property, $post_id = false, $format_value = true ) {
 	
-	$value = get_typography_field($selector, $property, $post_id, $format_value);
+	$value = get_typography_field( $selector, $property, $post_id, $format_value );
 	
-	if( is_array($value) ) {
+	if( is_array( $value ) ) {
 		$value = @implode( ', ', $value );
 	}
 	
@@ -75,9 +75,9 @@ function get_typography_sub_field( $selector, $property, $format_value = true, $
 	// bail early if no sub field
 	if( !$sub_field ) return false;
 	
-	if( is_array($sub_field['value']) && array_key_exists( $property, $sub_field['value'] ) )
-		$property_value = esc_attr($sub_field['value'][$property]);
-    else
+	if( is_array( $sub_field['value'] ) && array_key_exists( $property, $sub_field['value'] ) )
+		$property_value = esc_attr( $sub_field['value'][$property] );
+        else
 		$property_value = '';
 
 	// return 
@@ -94,7 +94,7 @@ function the_typography_sub_field( $field_name, $property, $format_value = true 
 	
 	$value = get_typography_sub_field( $field_name, $property, $format_value );
 	
-	if( is_array($value) ) {
+	if( is_array( $value ) ) {
 		
 		$value = implode(', ',$value);
 		
@@ -114,7 +114,7 @@ function the_typography_sub_field( $field_name, $property, $format_value = true 
 
 function acf_typography_shortcode( $atts ) {
 	
-	// extract attributs
+	// extract attributes
 	extract( shortcode_atts( array(
 		'field'			=> '',
 		'property'		=> '',
@@ -128,7 +128,7 @@ function acf_typography_shortcode( $atts ) {
 	
 	
 	// array
-	if( is_array($value) ) {
+	if( is_array( $value ) ) {
 		
 		$value = @implode( ', ', $value );
 		
@@ -140,4 +140,4 @@ function acf_typography_shortcode( $atts ) {
 	
 }
 
-add_shortcode('acf_typography', 'acf_typography_shortcode');
+add_shortcode( 'acf_typography', 'acf_typography_shortcode' );

--- a/includes/api-template.php
+++ b/includes/api-template.php
@@ -11,7 +11,7 @@ function get_typography_field( $selector, $property, $post_id = false, $format_v
 	$post_id = acf_get_valid_post_id( $post_id );
 	
 	// get field
-        $field = acf_maybe_get_field( $selector, $post_id );
+	$field = acf_maybe_get_field( $selector, $post_id );
 	
 	// create dummy field
 	if( !$field ) {	
@@ -26,22 +26,22 @@ function get_typography_field( $selector, $property, $post_id = false, $format_v
 	}
 	
 	// get value for field
-        $value = acf_get_value( $post_id, $field );
+	$value = acf_get_value( $post_id, $field );
 	
 	// format value
 	if( $format_value ) {	
 		// get value for field
 		$value = acf_format_value( $value, $post_id, $field );
-        }
-    
-        // get property
-        if( is_array( $value ) && array_key_exists( $property, $value ) )
-            $property_value = esc_attr( $value[ $property ] );
-        else
-            $property_value = '';
-    
+	}
+
+	// get property
+	if( is_array( $value ) && array_key_exists( $property, $value ) )
+		$property_value = esc_attr( $value[ $property ] );
+	else
+		$property_value = '';
+
 	return $property_value;
- 
+
 }
 
 /**
@@ -77,7 +77,7 @@ function get_typography_sub_field( $selector, $property, $format_value = true, $
 	
 	if( is_array( $sub_field['value'] ) && array_key_exists( $property, $sub_field['value'] ) )
 		$property_value = esc_attr( $sub_field['value'][$property] );
-        else
+	else
 		$property_value = '';
 
 	// return 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,5 +1,46 @@
 <?php
 
+
+/**
+ *  Get a valid post_id for the current object
+ * 
+ *  acft_get_valid_post_id( $post_id )
+ * 
+ *  @param	(str) $post_id (optional) 
+ *                  A post_id to retrieve fields
+ * 
+ *  @return	(str) post_id when valid post_id found, or 
+ *              (bool) false when no valid post_id is found 
+ * 
+ *  @since      3.2.4
+ */
+function acft_get_valid_post_id( $post_id = false ) {
+    
+    // supplied a post_id, use it
+    if ( $post_id ) {
+        $post_obj = get_post( intval( $post_id ) );
+        if ( is_object( $post_obj ) && !is_wp_error( $post_obj ) ) {
+            $post_id = $post_obj->ID;
+    }}
+    
+    // if no post_id, try getting post_id if called inside the loop
+    if ( $post_id === false ) {
+        global $post;
+        if ( is_object( $post ) ) {
+            $post_id = $post->ID;
+    }}
+
+    // if still no post_id, try getting post_id if called outside the loop
+    if ( $post_id === false ) {
+        global $wp_query; 
+        if ( is_object( $wp_query->post ) ) {
+            $post_id = $wp_query->post->ID;
+    }}
+    
+    return $post_id;
+}
+
+
 /**
  *  Update Google Fonts JSON file
  * 
@@ -18,17 +59,23 @@ function acft_update_gf_json_file( $API_KEY ) {
         $now = date ( "Ymd", time() );
         $time = $now - $file_date;
         
-        if ( !filesize($filename) || $time > 2 ) {
+        if ( !filesize( $filename ) || $time > 2 ) {
 
-            $json = file_get_contents('https://www.googleapis.com/webfonts/v1/webfonts?key=' . $API_KEY);
+            // suppress errors for now
+            $json = @file_get_contents( 'https://www.googleapis.com/webfonts/v1/webfonts?key=' . $API_KEY );
+            
+            // if we didn't get an error, save json data to file
+            if ( $json ) {
 
-            $gf_file = fopen($filename, 'wb');
-            fwrite($gf_file, $json);
-            fclose( $gf_file );
+                $gf_file = fopen( $filename, 'wb' );
+                fwrite( $gf_file, $json );
+                fclose( $gf_file );
+                
+            } // end if valid response check
 
-        }
+        } // end if json file empty / last check more than 2 days ago
 
-    }
+    } // end if json file exists check
 
 }
 
@@ -41,22 +88,22 @@ function acft_update_gf_json_file( $API_KEY ) {
  */
 function acft_get_google_font_family(){
 
-    if ( !defined('YOUR_API_KEY') ) return;
+    if ( !defined( 'YOUR_API_KEY' ) ) return;
 
     acft_update_gf_json_file( YOUR_API_KEY );
 
     // Load json file for extra seting
     $dir = plugin_dir_path( dirname(__FILE__) );
-    $json = file_get_contents("{$dir}google_fonts.json");
-    $fontArray = json_decode( $json);
+    $json = file_get_contents( "{$dir}google_fonts.json" );
+    $fontArray = json_decode( $json );
     $font_family = array();
 
     if( $fontArray ){
         foreach ( $fontArray as $k => $v ) {
-            if (is_array($v)){
-                foreach ($v as $value){
-                    foreach ($value as $key1 => $value1) {
-                        if($key1== "family"){
+            if ( is_array( $v ) ){
+                foreach ( $v as $value ){
+                    foreach ( $value as $key1 => $value1 ) {
+                        if( $key1== "family" ){
                             $font_family[ $value1 ] = $value1;
                         }		
                     }
@@ -69,23 +116,39 @@ function acft_get_google_font_family(){
 
 }
 
+
 /**
- *  Enqueue Google Fonts file
+ *  Get all fields for an object (post, block, option)
  * 
- *  acft_enqueue_google_fonts_file()
+ *  acft_get_all_fields( $post_id )
  * 
- *  @since		3.0.0
+ *  @param	$post_id (str) (optional) A post_id to retrieve fields
+ *  @return	(array) An array of any fields it could find for current object
+ * 
+ *  @since      3.2.4
  */
-add_action( 'wp_enqueue_scripts', 'acft_enqueue_google_fonts_file' );
-function acft_enqueue_google_fonts_file() {
+function acft_get_all_fields( $post_id = false ) {
     
-    global $post;
-    
-    $all_post_fields = get_fields( $post->ID, false ) ?: array();
+    // try to get a valid post_id, starting with optional supplied post_id
+    $post_id = acft_get_valid_post_id( $post_id );   
+            
+    // fields for options
     $all_option_fields = get_fields( 'option', false ) ?: array();
+            
+    // if no post_id, there's nothing to grab values for, so just return option fields array
+    if ( $post_id === false ) { return $all_option_fields; }
     
-    // for Gutenberg Blocks
-    $blocks = parse_blocks( $post->post_content );
+    
+    /* since we have a post_id, so let's grab post and block fields for it */
+    
+    // fields for posts
+    $all_post_fields = get_fields( $post_id, false ) ?: array();
+    
+    // get post object for this valid post_id
+    $post_obj = get_post( $post_id ); 
+
+    // fields for Gutenberg Blocks
+    $blocks = parse_blocks( $post_obj->post_content );
     foreach ( $blocks as $block ) {
         
         if ( strpos( $block['blockName'], 'acf/' ) === 0 ) { // a custom block made with ACF
@@ -95,37 +158,86 @@ function acft_enqueue_google_fonts_file() {
         }
         
     }
+
+    // merge post/block fields array with options array and return
+    return array_merge_recursive( $all_post_fields, $all_option_fields );
+
+}
+
+
+/**
+ *  Merge all supplied fields for an object (post, block, options)
+ * 
+ *  Returns an array of the font_family array and font_weight array
+ *  used for enqueuing font styles, and displaying with the (future) shortcode
+ * 
+ *  acft_merge_all_fields( $all_fields )
+ * 
+ *  @param	$all_fields (array) The array of collected fields for an object
+ *  @return	(array) An array of arrays - font family, font weight
+ * 
+ *  @since      3.2.4
+ */
+function acft_merge_all_fields( $all_fields = false ) {
     
-    $font_family = $font_weight = array();
+    $mergedArray = array();
+    $mergedArray['font_family'] = $mergedArray['font_weight'] = array();
 
-    $all_fields = array_merge_recursive( $all_post_fields, $all_option_fields );
+    if ( is_array( $all_fields ) ) {
 
-    if( is_array($all_fields) ){
-
-        array_walk_recursive($all_fields, function($item, $key) use (&$font_family, &$font_weight) {
-            if( $key === 'font_family' )
-			    if (!in_array($item, $font_family)) {
-				$font_family[] = $item;
-			}
-            elseif( $key === 'font_weight' ) {
-				if (!in_array($item, $font_weight)) {
-					$font_weight[] = $item;
-				}
-			}
+        array_walk_recursive( $all_fields, function( $item, $key ) use ( &$mergedArray ) {
+            if( $key === 'font_family' ) {
+                    if ( !in_array( $item, $mergedArray['font_family'] ) ) {
+                        $mergedArray['font_family'][] = $item;
+                    }
+            } elseif( $key === 'font_weight' ) {
+                    if ( !in_array( $item, $mergedArray['font_weight'] ) ) {
+                        $mergedArray['font_weight'][] = $item;
+                    }
+            }
         });
 
     }
+    
+    return $mergedArray;
+}
 
-    if( is_array($font_family) && count($font_family) > 0 ){
 
-        if( is_array($font_weight) && count($font_weight) > 0 ){
+
+/**
+ *  Enqueue Google Fonts file
+ * 
+ *  acft_enqueue_google_fonts_file()
+ * 
+ *  @since		3.0.0
+ */
+add_action( 'wp_enqueue_scripts', 'acft_enqueue_google_fonts_file' );
+function acft_enqueue_google_fonts_file() {
+   
+    // get all fields for current object
+    $all_fields = acft_get_all_fields();
+    
+    // merge all fields for current object
+    $merged_fields = acft_merge_all_fields( $all_fields );
+    
+    $font_family = $merged_fields['font_family'];
+    $font_weight = $merged_fields['font_weight'];
+    
+    // if there's actually a font_family present, then we enqueue the stylesheet
+    if( is_array( $font_family ) && count( $font_family ) > 0 ){
+
+        if( is_array( $font_weight ) && count( $font_weight ) > 0 ){
             $font_weight = implode( ',', $font_weight );
             $font_family = implode( ':'.$font_weight.'|', $font_family );
         }else{
             $font_family = implode( ':400,700|', $font_family );
         }
         
-        wp_enqueue_style( 'acft-gf', 'https://fonts.googleapis.com/css?family='.$font_family );
+        // wp_enqueue_style automatically replaces ' ' with '+', but some themes like (twentytwentytwo) include these 
+        // enqueued files through another method that does properly encode the URL string. We just go ahead and do it
+        // now to prevent 404 errors when a font_family name has a space in the name
+        wp_enqueue_style( 'acft-gf', 'https://fonts.googleapis.com/css?family='.str_replace(' ', '+', $font_family) );
+
 
     }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -15,14 +15,14 @@
  *  @since      3.2.4
  */
 function acft_get_valid_post_id( $post_id = false ) {
-    
+
     // supplied a post_id, use it
     if ( $post_id ) {
         $post_obj = get_post( intval( $post_id ) );
         if ( is_object( $post_obj ) && !is_wp_error( $post_obj ) ) {
             $post_id = $post_obj->ID;
     }}
-    
+
     // if no post_id, try getting post_id if called inside the loop
     if ( $post_id === false ) {
         global $post;
@@ -36,7 +36,7 @@ function acft_get_valid_post_id( $post_id = false ) {
         if ( is_object( $wp_query->post ) ) {
             $post_id = $wp_query->post->ID;
     }}
-    
+
     return $post_id;
 }
 
@@ -233,9 +233,11 @@ function acft_enqueue_google_fonts_file() {
             $font_family = implode( ':400,700|', $font_family );
         }
         
-        // wp_enqueue_style automatically replaces ' ' with '+', but some themes like (twentytwentytwo) include these 
-        // enqueued files through another method that does properly encode the URL string. We just go ahead and do it
-        // now to prevent 404 errors when a font_family name has a space in the name
+        /**
+         * wp_enqueue_style automatically replaces ' ' with '+', but some themes like (twentytwentytwo) include these 
+         * enqueued files through another method that does properly encode the URL string. We just go ahead and do it
+         * now to prevent 404 errors when a font_family name has a space in the name
+         */ 
         wp_enqueue_style( 'acft-gf', 'https://fonts.googleapis.com/css?family='.str_replace(' ', '+', $font_family) );
 
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -151,10 +151,13 @@ function acft_get_all_fields( $post_id = false ) {
     $blocks = parse_blocks( $post_obj->post_content );
     foreach ( $blocks as $block ) {
         
-        if ( strpos( $block['blockName'], 'acf/' ) === 0 ) { // a custom block made with ACF
-            
-            $all_post_fields[] = $block['attrs']['data'];
-            
+        // make sure we have a block to check (php8.2 compatibility for passing empty haystack deprecated)  
+        if ( isset( $block['blockName'] ) ) {
+            if ( strpos( $block['blockName'], 'acf/' ) === 0 ) { // a custom block made with ACF
+
+                $all_post_fields[] = $block['attrs']['data'];
+
+            }
         }
         
     }

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Advanced Custom Fields: Typography Field ===
-Contributors: mujahid158
+Contributors: mujahid158, codejp3
 Tags: typography, acf, advanced custom fields, addon, admin, field, custom, custom field, acf typography, acf google fonts, google fonts
 Requires at least: 3.5.0
 Tested up to: 6.0
-Stable tag: 3.2.3
+Stable tag: 3.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -12,6 +12,8 @@ A Typography Add-on for the Advanced Custom Fields Plugin.
 == Description ==
 
 Typography field type for "Advanced Custom Fields" plugin that lets you add different text properties e.g. Font Size, Font Family, Font Color etc.
+
+If you want any kind of font/typography features within ACF, this is the plugin for you! There's nothing else like it!
 
 = Supported Subfields =
 * Font Size
@@ -58,6 +60,7 @@ the_typography_sub_field( $selector, $property, [$format_value] );
 = Compatibility =
 
 This ACF field type is compatible with:
+* ACF plugin v4, v5 & v6
 * Free and paid versions of the ACF plugin
 
 == Installation ==
@@ -69,8 +72,11 @@ This ACF field type is compatible with:
 5. Please refer to the description for more info regarding the field type settings
 
 == Frequently Asked Questions ==
+= Q. Which versions of ACF is this plugin compatible with? =
+A. It is compatible with V4, V5, and the latest v6. There are 2 known UI bugs with v6 (number fields & color_picker fields) but functionality works, and we are currently working with the ACF plugin authors to resolve the visual issues present in v6.
+
 = Q. Is it compatible with ACF Pro? =
-A. Yes. This plugin is compatiable with both free and paid ACF plugins.
+A. Yes. This plugin is compatible with both free and paid ACF plugins.
 
 = Q. Does it support Google Fonts? =
 A. Version 3.0.0 and greater supports Google Fonts
@@ -99,6 +105,18 @@ A. Join in on Github repository [@mujahidi/acf-typography](https://github.com/mu
 
 
 == Changelog ==
+= 3.2.4 =
+* [NEW] Plugin now officially supports ACF v6!
+* [NEW] Tested up to PHP 8.2.
+* [BUG] Fixed 'Notice: Trying to get property ID of non-object' when enqueueing font files on non-objects. ( WP Support )
+* [BUG] Fixed 'Warning: failed to open stream: HTTP request failed' when bad API Key supplied, or other API connection issues. #27
+* [NEW] Admin Settings - checks and help messages for Google API Key/connection issues.
+* [NEW] Admin Settings - description and link provided for getting Google Fonts API key.
+* [NEW] Admin Settings - checks to make sure ACF is installed and activated.
+* [UPDATE] Translation string and textdomain updates to get plugin translation-ready (coming next release).
+* [UPDATE] Added a few minor additional checks for some variables to prevent possible errors in the future.
+* [UPDATE] Minor code cleanup for readability. 
+
 = 3.2.3 =
 * Added new font-weight values
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: mujahid158, codejp3
 Tags: typography, acf, advanced custom fields, addon, admin, field, custom, custom field, acf typography, acf google fonts, google fonts
 Requires at least: 3.5.0
-Tested up to: 6.0
+Tested up to: 6.0.3
 Stable tag: 3.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
@mujahidi - Tested and ready for final review.

It may seem like a lot, but the bulk majority of it is just code cleanup with tabs/spaces for easier readability. 

I've tested against ACF v5 & v6. Both are functioning properly, but I found 2 UI visual bugs with v6:
- number field append "px" has really huge gap. It is a core ACF issue and I have notified them.
- color_picker field has a wrong sized button. Also a core ACF issue and I have notified them.

I figured you may want to change some of the wording for things. That's why it will be the NEXT release that officially supports translations ( #24 ) after you re-word anything to your liking. This release was just getting it prepared for it.


### Highlights for actual code changes:

**functions.php:**
- Your enqueue function has been split into 4 functions:
-- one handles post_id stuff and fixes the issue with trying to get an id of a non-object (WP Support topic)
-- one handles getting the values for fields (based on valid post_id)
-- one handles merging the values for fields (based on supplied values)
-- one handles enqueueing the stylesheet (based on merged values)
- Checks for getting good results back for google_fonts.json file ( #27 )
- All new functions are setup and ready for integration with future enhancements (like saving stylesheets/font files locally)
- The rest is minor code cleanup

**admin_settings.php**
- Admin error messages if bad API Key or network issues ( #27 )
- Admin error messages if ACF not installed/activated
- Translation / Text Domain changes to get plugin ready for translations (next release)

**acf-typography.php**
- Translation / Text Domain changes to get plugin ready for translations (next release)
- Handle ACF versions proactively until ACF implements it in ACF core. Now supports ACF v6.

**acf-Typography-v5.php**
- changed field type from "text" to "color_picker" for text_color field which ACF v5 & v6 support.

**acf-Typography-v6.php**
- placeholder file that points to acf-Typography-v5.php for now, but is the future home for any v6-specific field changes


That's really about it. Everything else is superficial, minor code cleanup, and has zero impact on functionality.
